### PR TITLE
Expose all constant queries as Client functions

### DIFF
--- a/api.go
+++ b/api.go
@@ -94,7 +94,7 @@ func API_History(c *gin.Context) {
 }
 
 func API_Info(c *gin.Context) {
-	res, err := dbClient.Query(PG_INFO)
+	res, err := dbClient.Info()
 
 	if err != nil {
 		c.JSON(400, NewError(err))

--- a/client.go
+++ b/client.go
@@ -48,6 +48,10 @@ func (client *Client) recordQuery(query string) {
 	client.history = append(client.history, query)
 }
 
+func (client *Client) Info() (*Result, error) {
+	return client.Query(PG_INFO)
+}
+
 func (client *Client) Databases() ([]string, error) {
 	res, err := client.Query(PG_DATABASES)
 


### PR DESCRIPTION
Rather than have consumers call `Sprintf` directly.
