### PR TITLE
Fixed typo in connection string example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ pgweb --host localhost --user myuser --db mydb
 You can also specify a connection URI instead of individual flags:
 
 ```
-pgweb --url postgresql://user:password@host:port/database
+pgweb --url postgres://user:password@host:port/database
 ```
 
 It works great with [Heroku Postgres](https://postgres.heroku.com) if you need 


### PR DESCRIPTION
Previous --url example has a typo that causes an error. 
Correct syntax is 'postgres' not 'postgresql'.
