### PR TITLE
Use DATABASE_URL environment variable if no Url is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,10 @@ func initOptions() {
 		os.Exit(1)
 	}
 
+	if options.Url == "" {
+		options.Url = os.Getenv("DATABASE_URL")
+	}
+
 	if options.Version {
 		fmt.Printf("pgweb v%s\n", VERSION)
 		os.Exit(0)


### PR DESCRIPTION
Default to `DATABASE_URL` if no `options.Url` is set. 

If `DATABASE_URL` is set, any `--host` or other parameters are ignored.
