### PR TITLE
Implement HTTP basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,18 @@ Usage:
   pgweb [OPTIONS]
 
 Application Options:
-  -v, --version  Print version
-  -d, --debug    Enable debugging mode (false)
-      --url=     Database connection string
-      --host=    Server hostname or IP (localhost)
-      --port=    Server port (5432)
-      --user=    Database user (postgres)
-      --pass=    Password for user
-      --db=      Database name (postgres)
-      --ssl=     SSL option (disable)
-      --listen=  HTTP server listen port (8080)
+  -v, --version    Print version
+  -d, --debug      Enable debugging mode (false)
+      --url=       Database connection string
+      --host=      Server hostname or IP (localhost)
+      --port=      Server port (5432)
+      --user=      Database user (postgres)
+      --pass=      Password for user
+      --db=        Database name (postgres)
+      --ssl=       SSL option (disable)
+      --listen=    HTTP server listen port (8080)
+      --auth-user= HTTP basic auth user
+      --auth-pass= HTTP basic auth password
 ```
 
 ## Compile from source

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ var options struct {
 	DbName   string `long:"db" description:"Database name" default:"postgres"`
 	Ssl      string `long:"ssl" description:"SSL option" default:"disable"`
 	HttpPort uint   `long:"listen" description:"HTTP server listen port" default:"8080"`
+	AuthUser string `long:"auth-user" description:"HTTP basic auth user"`
+	AuthPass string `long:"auth-pass" description:"HTTP basic auth password"`
 }
 
 var dbClient *Client
@@ -95,6 +97,12 @@ func initOptions() {
 
 func startServer() {
 	router := gin.Default()
+
+	// Enable HTTP basic authentication only if both user and password are set
+	if options.AuthUser != "" && options.AuthPass != "" {
+		auth := map[string]string{options.AuthUser: options.AuthPass}
+		router.Use(gin.BasicAuth(auth))
+	}
 
 	router.GET("/", API_Home)
 	router.GET("/databases", API_GetDatabases)


### PR DESCRIPTION
This PR adds support for HTTP basic authentication.

Example:

```
pgweb --url mydb --auth-user foo --auth-pass bar
```
