### PR TITLE
Use entrypoint for dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,10 @@
 FROM golang:1.3
 
-ENV PGHOST localhost
-ENV PGPORT 5432
-ENV PGUSER postgres
-ENV PGDATABASE postgres
-
-ADD . /go/src/pgweb
+COPY . /go/src/pgweb
 WORKDIR /go/src/pgweb
 
 RUN touch Makefile
 RUN make setup
 RUN make dev
 
-CMD pgweb --host $PGHOST --port $PGPORT --user $PGUSER --db $PGDATABASE
+ENTRYPOINT ["pgweb"]


### PR DESCRIPTION
Just a nicer way to run the docker container. Let's us pass flags directly
to the pgweb binary.

Env variables are unnecessary since you have defaults anyways.
