### PR TITLE
Added key binding for explain

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -253,8 +253,7 @@ function initEditor() {
   editor.getSession().setMode("ace/mode/pgsql");
   editor.getSession().setTabSize(2);
   editor.getSession().setUseSoftTabs(true);
-
-  editor.commands.addCommand({
+  editor.commands.addCommands([{
     name: "run_query",
     bindKey: {
       win: "Ctrl-Enter",
@@ -263,7 +262,16 @@ function initEditor() {
     exec: function(editor) {
       runQuery();
     }
-  });
+  }, {
+    name: "explain_query",
+    bindKey: {
+      win: "Ctrl-E",
+      mac: "Command-E"
+    },
+    exec: function(editor) {
+      runExplain();
+    }
+  }]);
 }
 
 $(document).ready(function() {


### PR DESCRIPTION
Similar to https://github.com/sosedoff/pgweb/commit/ad0bc43eeb5c42b67646f1d06d01918fcdb50264 where a keyboard binding was added for running the query, a keyboard binding for explains will also be useful.

I like using `CMD + E`, thoughts?
