### PR TITLE
Reduce duplication in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,22 @@
-dev:
-	rm -f bindata.go
-	go-bindata -debug -ignore=\\.gitignore -ignore=\\.DS_Store -ignore=\\.gitkeep static/...
+BINDATA=
+
+dev: build-dev-assets
 	go build
 	@echo "You can now execute ./pgweb"
 
-build:
-	rm -f bindata.go
-	go-bindata -ignore=\\.gitignore -ignore=\\.DS_Store -ignore=\\.gitkeep static/...
+build-assets:
+	go-bindata $(BINDATA) -ignore=\\.gitignore -ignore=\\.DS_Store -ignore=\\.gitkeep static/...
+
+build-dev-assets:
+	@$(MAKE) --no-print-directory build-assets BINDATA="-debug"
+
+build: build-assets
 	gox -osarch="darwin/amd64 darwin/386 linux/amd64 linux/386 windows/amd64 windows/386" -output="./bin/pgweb_{{.OS}}_{{.Arch}}"
 
 setup:
 	go get github.com/mitchellh/gox
 	go get github.com/jteeuwen/go-bindata/...
-	go-bindata -debug -ignore=\\.gitignore -ignore=\\.DS_Store -ignore=\\.gitkeep static/...
+	@$(MAKE) --no-print-directory build-dev-assets
 	go get
 
 clean:


### PR DESCRIPTION
- ~~Install `gox` and `go-bindata` only when not installed~~
- Have only one target that specifies the asset bindata
- Build assets as normal dependencies

This also makes it easy to commit generated files as part of a pre-commit hook, e.g.,

``` sh
#!/bin/sh

git diff --cached --name-only | grep -qv '^static/' || (
        make build-assets && git add -f bindata.go && make build-dev-assets
)
```
