### PR TITLE
Added basic support for multiple schemas.

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/jmoiron/sqlx"
 	"reflect"
+	"strings"
 )
 
 type Client struct {
@@ -69,15 +70,26 @@ func (client *Client) Tables() ([]string, error) {
 
 	var tables []string
 
+	schemasToSkip := map[string]bool {
+		"information_schema": true,
+		"pg_catalog": true,
+	}
+
 	for _, row := range res.Rows {
-		tables = append(tables, row[0].(string))
+		var schemaName = row[0].(string)
+		var tableName = row[1].(string)
+		if schemasToSkip[schemaName] {
+			continue
+		}
+		tables = append(tables, schemaName + "." + tableName)
 	}
 
 	return tables, nil
 }
 
 func (client *Client) Table(table string) (*Result, error) {
-	return client.Query(fmt.Sprintf(PG_TABLE_SCHEMA, table))
+	names := strings.Split(table, ".")
+	return client.Query(fmt.Sprintf(PG_TABLE_SCHEMA, names[0], names[1]))
 }
 
 func (client *Client) TableInfo(table string) (*Result, error) {
@@ -85,7 +97,8 @@ func (client *Client) TableInfo(table string) (*Result, error) {
 }
 
 func (client *Client) TableIndexes(table string) (*Result, error) {
-	res, err := client.Query(fmt.Sprintf(PG_TABLE_INDEXES, table))
+	names := strings.Split(table, ".")
+	res, err := client.Query(fmt.Sprintf(PG_TABLE_INDEXES, names[0], names[1]))
 
 	if err != nil {
 		return nil, err

--- a/statements.go
+++ b/statements.go
@@ -3,8 +3,8 @@ package main
 const (
 	PG_INFO          = "SELECT version(), user, current_database(), inet_client_addr(), inet_client_port(), inet_server_addr(), inet_server_port()"
 	PG_DATABASES     = "SELECT datname FROM pg_database WHERE datistemplate = false ORDER BY datname ASC;"
-	PG_TABLES        = "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' ORDER BY table_schema,table_name;"
-	PG_TABLE_SCHEMA  = "SELECT column_name, data_type, is_nullable, character_maximum_length, character_set_catalog, column_default FROM information_schema.columns where table_name = '%s';"
-	PG_TABLE_INDEXES = "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = '%s';"
+	PG_TABLES        = "SELECT table_schema, table_name FROM information_schema.tables ORDER BY table_schema,table_name;"
+	PG_TABLE_SCHEMA  = "SELECT column_name, data_type, is_nullable, character_maximum_length, character_set_catalog, column_default FROM information_schema.columns where table_schema = '%s' AND table_name = '%s';"
+	PG_TABLE_INDEXES = "SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = '%s' AND tablename = '%s';"
 	PG_TABLE_INFO    = "SELECT pg_size_pretty(pg_table_size('%s')) AS data_size, pg_size_pretty(pg_indexes_size('%s')) AS index_size, pg_size_pretty(pg_total_relation_size('%s')) AS total_size, (SELECT COUNT(*) FROM %s) AS rows_count"
 )

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -148,7 +148,9 @@ function showTableContent() {
     return;
   }
 
-  var query = "SELECT * FROM " + name + " LIMIT 100;";
+  // The name will be of the form 'schema.table'.
+  var names = name.split('.', 2);
+  var query = "SELECT * FROM \"" + names[0] + "\".\"" + names[1] + "\" LIMIT 100;";
 
   executeQuery(query, function(data) {
     buildTable(data);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -148,7 +148,7 @@ function showTableContent() {
     return;
   }
 
-  var query = "SELECT * FROM \"" + name + "\" LIMIT 100;";
+  var query = "SELECT * FROM " + name + " LIMIT 100;";
 
   executeQuery(query, function(data) {
     buildTable(data);


### PR DESCRIPTION
Issue #14. This will just list all tables in all schemas (except information_schema and pg_catalog) in the list on the left. Even better would be to group the schemas in the table on the left, but that should be an easy client-side change.