### PR TITLE
Do not include files ignored by Git in compiled assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-BINDATA_IGNORE = $(shell git ls-files -io --exclude-standard static/ | sed 's/^/-ignore=/;s/[.]/[.]/g')
+BINDATA_IGNORE = $(shell git ls-files -io --exclude-standard $< | sed 's/^/-ignore=/;s/[.]/[.]/g')
 
 dev: dev-assets
 	godep go build
 	@echo "You can now execute ./pgweb"
 
-assets:
-	go-bindata $(BINDATA_OPTS) $(BINDATA_IGNORE) -ignore=[.]gitignore -ignore=[.]gitkeep static/...
+assets: static/
+	go-bindata $(BINDATA_OPTS) $(BINDATA_IGNORE) -ignore=[.]gitignore -ignore=[.]gitkeep $<...
 
 dev-assets:
 	@$(MAKE) --no-print-directory assets BINDATA_OPTS="-debug"


### PR DESCRIPTION
Twice I nearly committed Vim swapfiles into `bindata.go`.

This automatically adds files that exist under `static/` and [match user- and project-configured ignores](https://www.kernel.org/pub/software/scm/git/docs/git-ls-files.html) to the ignore list of `go-bindata`.

```
➜ make assets 
go-bindata   -ignore=static/js/[.]app[.]js[.]swp \
                -ignore=[.]gitignore -ignore=[.]gitkeep static/...
```
