### PR TITLE
Convert bigints that exceed js number limits to strings

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -207,6 +207,8 @@ func HandleQuery(query string, c *gin.Context) {
 		c.Writer.Header().Set("Content-disposition", "attachment;filename="+filename)
 	}
 
+	result.PrepareBigints()
+
 	switch format {
 	case "csv":
 		c.Data(200, "text/csv", result.CSV())

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -207,8 +207,6 @@ func HandleQuery(query string, c *gin.Context) {
 		c.Writer.Header().Set("Content-disposition", "attachment;filename="+filename)
 	}
 
-	result.PrepareBigints()
-
 	switch format {
 	case "csv":
 		c.Data(200, "text/csv", result.CSV())

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -193,6 +193,8 @@ func (client *Client) query(query string, args ...interface{}) (*Result, error) 
 		}
 	}
 
+	result.PrepareBigints()
+
 	return &result, nil
 }
 

--- a/pkg/client/result.go
+++ b/pkg/client/result.go
@@ -25,8 +25,17 @@ func (res *Result) PrepareBigints() {
 				continue
 			}
 
-			if reflect.TypeOf(col).Kind() == reflect.Int64 {
-				res.Rows[i][j] = strconv.FormatInt(col.(int64), 10)
+			switch reflect.TypeOf(col).Kind() {
+			case reflect.Int64:
+				val := col.(int64)
+				if val < -9007199254740991 || val > 9007199254740991 {
+					res.Rows[i][j] = strconv.FormatInt(col.(int64), 10)
+				}
+			case reflect.Float64:
+				val := col.(float64)
+				if val < -999999999999999 || val > 999999999999999 {
+					res.Rows[i][j] = strconv.FormatFloat(val, 'e', -1, 64)
+				}
 			}
 		}
 	}

--- a/pkg/client/result.go
+++ b/pkg/client/result.go
@@ -5,6 +5,8 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strconv"
 )
 
 type Row []interface{}
@@ -12,6 +14,22 @@ type Row []interface{}
 type Result struct {
 	Columns []string `json:"columns"`
 	Rows    []Row    `json:"rows"`
+}
+
+// Due to big int number limitations in javascript, numbers should be encoded
+// as strings so they could be properly loaded on the frontend.
+func (res *Result) PrepareBigints() {
+	for i, row := range res.Rows {
+		for j, col := range row {
+			if col == nil {
+				continue
+			}
+
+			if reflect.TypeOf(col).Kind() == reflect.Int64 {
+				res.Rows[i][j] = strconv.FormatInt(col.(int64), 10)
+			}
+		}
+	}
 }
 
 func (res *Result) Format() []map[string]interface{} {

--- a/pkg/client/result_test.go
+++ b/pkg/client/result_test.go
@@ -7,6 +7,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_PrepareBigints(t *testing.T) {
+	result := Result{
+		Columns: []string{"value"},
+		Rows: []Row{
+			Row{int(1234)},
+			Row{int64(9223372036854775807)},
+			Row{int64(-9223372036854775808)},
+		},
+	}
+
+	result.PrepareBigints()
+
+	assert.Equal(t, 1234, result.Rows[0][0])
+	assert.Equal(t, "9223372036854775807", result.Rows[1][0])
+	assert.Equal(t, "-9223372036854775808", result.Rows[2][0])
+}
+
 func Test_CSV(t *testing.T) {
 	result := Result{
 		Columns: []string{"id", "name", "email"},

--- a/pkg/client/result_test.go
+++ b/pkg/client/result_test.go
@@ -14,6 +14,8 @@ func Test_PrepareBigints(t *testing.T) {
 			Row{int(1234)},
 			Row{int64(9223372036854775807)},
 			Row{int64(-9223372036854775808)},
+			Row{float64(9223372036854775808.9223372036854775808)},
+			Row{float64(999999999999999.9)},
 		},
 	}
 
@@ -22,6 +24,8 @@ func Test_PrepareBigints(t *testing.T) {
 	assert.Equal(t, 1234, result.Rows[0][0])
 	assert.Equal(t, "9223372036854775807", result.Rows[1][0])
 	assert.Equal(t, "-9223372036854775808", result.Rows[2][0])
+	assert.Equal(t, "9.223372036854776e+18", result.Rows[3][0])
+	assert.Equal(t, "9.999999999999999e+14", result.Rows[4][0])
 }
 
 func Test_CSV(t *testing.T) {


### PR DESCRIPTION
Should fix #108 