### PR TITLE
Only view schema with USAGE privileges

### DIFF
--- a/pkg/statements/sql.go
+++ b/pkg/statements/sql.go
@@ -149,6 +149,7 @@ LEFT JOIN
 WHERE
   c.relkind IN ('r','v','m','S','s','') AND
   n.nspname !~ '^pg_toast' AND 
-  n.nspname NOT IN ('information_schema', 'pg_catalog')
+  n.nspname NOT IN ('information_schema', 'pg_catalog') AND
+  has_schema_privilege(n.nspname, 'USAGE')
 ORDER BY 1, 2`
 )


### PR DESCRIPTION
This change makes a schema visible (i.e. viewable on the left panel) only if the current user has access to it.

On a complex database it can get quite messy without this being set.

I didn't include the modified `bindata.go` file in this pull request, what is the procedure for updating this file?
