### PR TITLE
Fix base64 padding with multiple =-signs. An equal amount of dots is …

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -96,7 +96,7 @@ function explainQuery(query, cb)            { apiCall("post", "/explain", { quer
 function disconnect(cb)                     { apiCall("post", "/disconnect", {}, cb); }
 
 function encodeQuery(query) {
-  return window.btoa(query).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, ".");
+  return window.btoa(query).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, ".");
 }
 
 function buildSchemaSection(name, objects) {


### PR DESCRIPTION
…required in output

instead of merging all =-signs into one dot, which can then not be decoded. Test string:

```SELECT * from version  where "isHelper" order by "order" desc;```

will be encode to

U0VMRUNUICogZnJvbSB2ZXJzaW9uICB3aGVyZSAiaXNIZWxwZXIiIG9yZGVyIGJ5ICJvcmRlciIgZGVzYw.

missing a dot at the end making it undecodable.

Since =-signs only appear at the end anyway, we don't need the explicit '$' in the regexp