### PR TITLE
Read only mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,15 @@ func initOptions() {
 		os.Exit(0)
 	}
 
+	if options.ReadOnly {
+		msg := `------------------------------------------------------
+SECURITY WARNING: You are running pgweb in read-only mode.
+This mode is designed for environments where users could potentially delete / change data.
+For proper read-only access please follow postgresql role management documentation.
+------------------------------------------------------`
+		fmt.Println(msg)
+	}
+
 	printVersion()
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -232,7 +232,7 @@ func (client *Client) SetReadOnlyMode() error {
 	}
 
 	if value == "off" {
-		_, err = client.db.Exec("SET default_transaction_read_only=on;")
+		_, err := client.db.Exec("SET default_transaction_read_only=on;")
 		return err
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -225,7 +225,29 @@ func (client *Client) Query(query string) (*Result, error) {
 	return res, err
 }
 
+func (client *Client) SetReadOnlyMode() error {
+	var value string
+	if err := client.db.Get(&value, "SHOW default_transaction_read_only;"); err != nil {
+		return err
+	}
+
+	if value == "off" {
+		_, err = client.db.Exec("SET default_transaction_read_only=on;")
+		return err
+	}
+
+	return nil
+}
+
 func (client *Client) query(query string, args ...interface{}) (*Result, error) {
+	// We're going to force-set transaction mode on every query.
+	// This is needed so that default mode could not be changed by user.
+	if command.Opts.ReadOnly {
+		if err := client.SetReadOnlyMode(); err != nil {
+			return nil, err
+		}
+	}
+
 	action := strings.ToLower(strings.Split(query, " ")[0])
 	if action == "update" || action == "delete" {
 		res, err := client.db.Exec(query, args...)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -333,6 +333,18 @@ func test_HistoryUniqueness(t *testing.T) {
 	assert.Equal(t, "SELECT * FROM books WHERE id = 1", client.History[0].Query)
 }
 
+func test_ReadOnlyMode(t *testing.T) {
+	url := fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, serverDatabase)
+	client, _ := NewFromUrl(url, nil)
+
+	err := client.SetReadOnlyMode()
+	assert.Equal(t, nil, err)
+
+	_, err = client.Query("CREATE TABLE foobar(id integer);")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "in a read-only transaction")
+}
+
 func TestAll(t *testing.T) {
 	if onWindows() {
 		// Dont have access to windows machines at the moment...
@@ -362,6 +374,7 @@ func TestAll(t *testing.T) {
 	test_ResultCsv(t)
 	test_History(t)
 	test_HistoryError(t)
+	test_ReadOnlyMode(t)
 
 	teardownClient()
 	teardown()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -373,6 +373,7 @@ func TestAll(t *testing.T) {
 	test_TableRowsOrderEscape(t)
 	test_ResultCsv(t)
 	test_History(t)
+	test_HistoryUniqueness(t)
 	test_HistoryError(t)
 	test_ReadOnlyMode(t)
 

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -24,6 +24,7 @@ type Options struct {
 	SkipOpen bool   `short:"s" long:"skip-open" description:"Skip browser open on start"`
 	Sessions bool   `long:"sessions" description:"Enable multiple database sessions" default:"false"`
 	Prefix   string `long:"prefix" description:"Add a url prefix"`
+	ReadOnly bool   `long:"readonly" description:"Run database connection in readonly mode"`
 }
 
 var Opts Options


### PR DESCRIPTION
Implements #192.
The feature itself should not be considered a security measure since user can override the read-only mode in any query. For true read-only mode it should be part of the user/db permissions. 
Running with `--readonly` flag is intended for environments where users can accidentally delete data.