### PR TITLE
Example Configuration File for Ubuntu 14.04

### DIFF
--- a/examples/pgweb_upstart.conf
+++ b/examples/pgweb_upstart.conf
@@ -1,0 +1,10 @@
+description "PgWeb as a Service for Ubuntu 14.04 With Upstart"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+setuid youruser
+setgid www-data
+
+exec /usr/bin/pgweb --bind=0.0.0.0 --listen=8081


### PR DESCRIPTION
Example Configuration File for Ubuntu 14.04 and Upstart, normally in:
/etc/init/