### PR TITLE
Ability to override bookmarks directory + typo fix

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func initClient() {
 	var err error
 
 	if options.Bookmark != "" {
-		cl, err = initClientUsingBookmark(bookmarks.Path(), options.Bookmark)
+		cl, err = initClientUsingBookmark(bookmarks.Path(options.BookmarksDir), options.Bookmark)
 	} else {
 		cl, err = client.New()
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -376,7 +376,7 @@ func HandleQuery(query string, c *gin.Context) {
 	case "csv":
 		c.Data(200, "text/csv", result.CSV())
 	case "json":
-		c.Data(200, "applicaiton/json", result.JSON())
+		c.Data(200, "application/json", result.JSON())
 	case "xml":
 		c.XML(200, result)
 	default:
@@ -385,7 +385,7 @@ func HandleQuery(query string, c *gin.Context) {
 }
 
 func GetBookmarks(c *gin.Context) {
-	bookmarks, err := bookmarks.ReadAll(bookmarks.Path())
+	bookmarks, err := bookmarks.ReadAll(bookmarks.Path(command.Opts.BookmarksDir))
 	serveResult(bookmarks, err, c)
 }
 

--- a/pkg/bookmarks/bookmarks.go
+++ b/pkg/bookmarks/bookmarks.go
@@ -62,9 +62,13 @@ func fileBasename(path string) string {
 	return strings.Replace(filename, filepath.Ext(path), "", 1)
 }
 
-func Path() string {
-	path, _ := homedir.Dir()
-	return fmt.Sprintf("%s/.pgweb/bookmarks", path)
+func Path(overrideDir string) string {
+	if overrideDir == "" {
+		path, _ := homedir.Dir()
+		return fmt.Sprintf("%s/.pgweb/bookmarks", path)
+	}
+
+	return overrideDir
 }
 
 func ReadAll(path string) (map[string]Bookmark, error) {

--- a/pkg/bookmarks/bookmarks_test.go
+++ b/pkg/bookmarks/bookmarks_test.go
@@ -44,7 +44,7 @@ func Test_Bookmark_URL(t *testing.T) {
 }
 
 func Test_Bookmarks_Path(t *testing.T) {
-	assert.NotEqual(t, "/.pgweb/bookmarks", Path())
+	assert.NotEqual(t, "/.pgweb/bookmarks", Path(""))
 }
 
 func Test_Basename(t *testing.T) {

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -8,25 +8,26 @@ import (
 )
 
 type Options struct {
-	Version     bool   `short:"v" long:"version" description:"Print version"`
-	Debug       bool   `short:"d" long:"debug" description:"Enable debugging mode" default:"false"`
-	Url         string `long:"url" description:"Database connection string"`
-	Host        string `long:"host" description:"Server hostname or IP"`
-	Port        int    `long:"port" description:"Server port" default:"5432"`
-	User        string `long:"user" description:"Database user"`
-	Pass        string `long:"pass" description:"Password for user"`
-	DbName      string `long:"db" description:"Database name"`
-	Ssl         string `long:"ssl" description:"SSL option"`
-	HttpHost    string `long:"bind" description:"HTTP server host" default:"localhost"`
-	HttpPort    uint   `long:"listen" description:"HTTP server listen port" default:"8081"`
-	AuthUser    string `long:"auth-user" description:"HTTP basic auth user"`
-	AuthPass    string `long:"auth-pass" description:"HTTP basic auth password"`
-	SkipOpen    bool   `short:"s" long:"skip-open" description:"Skip browser open on start"`
-	Sessions    bool   `long:"sessions" description:"Enable multiple database sessions" default:"false"`
-	Prefix      string `long:"prefix" description:"Add a url prefix"`
-	ReadOnly    bool   `long:"readonly" description:"Run database connection in readonly mode"`
-	LockSession bool   `long:"lock-session" description:"Lock session to a single database connection" default:"false"`
-	Bookmark    string `short:"b" long:"bookmark" description:"Bookmark to use for connection. Bookmark files are stored under $HOME/.pgweb/bookmarks/*.toml" default:""`
+	Version      bool   `short:"v" long:"version" description:"Print version"`
+	Debug        bool   `short:"d" long:"debug" description:"Enable debugging mode" default:"false"`
+	Url          string `long:"url" description:"Database connection string"`
+	Host         string `long:"host" description:"Server hostname or IP"`
+	Port         int    `long:"port" description:"Server port" default:"5432"`
+	User         string `long:"user" description:"Database user"`
+	Pass         string `long:"pass" description:"Password for user"`
+	DbName       string `long:"db" description:"Database name"`
+	Ssl          string `long:"ssl" description:"SSL option"`
+	HttpHost     string `long:"bind" description:"HTTP server host" default:"localhost"`
+	HttpPort     uint   `long:"listen" description:"HTTP server listen port" default:"8081"`
+	AuthUser     string `long:"auth-user" description:"HTTP basic auth user"`
+	AuthPass     string `long:"auth-pass" description:"HTTP basic auth password"`
+	SkipOpen     bool   `short:"s" long:"skip-open" description:"Skip browser open on start"`
+	Sessions     bool   `long:"sessions" description:"Enable multiple database sessions" default:"false"`
+	Prefix       string `long:"prefix" description:"Add a url prefix"`
+	ReadOnly     bool   `long:"readonly" description:"Run database connection in readonly mode"`
+	LockSession  bool   `long:"lock-session" description:"Lock session to a single database connection" default:"false"`
+	Bookmark     string `short:"b" long:"bookmark" description:"Bookmark to use for connection. Bookmark files are stored under $HOME/.pgweb/bookmarks/*.toml" default:""`
+	BookmarksDir string `long:"bookmarks-dir" description:"Overrides default directory for bookmark files to search" default:""`
 }
 
 var Opts Options


### PR DESCRIPTION
I had troubles with `homedir` package on specific installation (can provide more info later), so thought it could be awesome to just override default bookmarks directory from a command line argument.

Also found a typo in a neighbouring MIME type