### PR TITLE
api: properly check for errors

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -109,11 +109,11 @@ func Connect(c *gin.Context) {
 	info, err := cl.Info()
 	if err == nil {
 		err = setClient(c, cl)
-		if err != nil {
-			cl.Close()
-			c.JSON(400, Error{err.Error()})
-			return
-		}
+	}
+	if err != nil {
+		cl.Close()
+		c.JSON(400, Error{err.Error()})
+		return
 	}
 
 	c.JSON(200, info.Format()[0])
@@ -163,11 +163,11 @@ func SwitchDb(c *gin.Context) {
 	info, err := cl.Info()
 	if err == nil {
 		err = setClient(c, cl)
-		if err != nil {
-			cl.Close()
-			c.JSON(400, Error{err.Error()})
-			return
-		}
+	}
+	if err != nil {
+		cl.Close()
+		c.JSON(400, Error{err.Error()})
+		return
 	}
 
 	conn.Close()


### PR DESCRIPTION
This results in NPE when cl.Info() returns an error.

Discovered this while attempting to use pgweb with [CockroachDB](https://github.com/cockroachdb/cockroach). Unfortunately, I hit another roadblock after fixing this: much of the [`Info` query](https://github.com/sosedoff/pgweb/blob/v0.9.7/pkg/statements/sql.go#L26:L36) is unsupported:
```sql
SELECT
  session_user, # invalid syntax: statement ignored: unimplemented at or near "session_user"
  current_user, # invalid syntax: statement ignored: unimplemented at or near "current_user"
  current_database(), # supported!
  current_schemas(false), # supported!
  inet_client_addr(), # pq: unknown function: inet_client_addr()
  inet_client_port(), # pq: unknown function: inet_client_port()
  inet_server_addr(), # pq: unknown function: inet_server_addr()
  inet_server_port(), # pq: unknown function: inet_server_port()
  version() # supported, returns "CockroachDB CCL eb8f08f3a (darwin amd64, built 2017/04/29 20:46:22, go1.8.1)"
```

I'll file an issue for CRDB support with these details as well.