### PR TITLE
Show query waiting for 9.6 in activity section

### DIFF
--- a/pkg/statements/sql.go
+++ b/pkg/statements/sql.go
@@ -141,6 +141,6 @@ var (
 		"9.3":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
 		"9.4":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
 		"9.5":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
-		"9.6":     "SELECT datname, query, state, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
+		"9.6":     "SELECT datname, query, state, wait_event, wait_event_type, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
 	}
 )


### PR DESCRIPTION
Follow up to #237. See [my comment there](https://github.com/sosedoff/pgweb/pull/237#issuecomment-300672295).

If the UI depends on the `waiting` column name (I couldn't see that it did), this could alternatively just select `wait_event IS NOT NULL as waiting` to be effectively the same as 9.0-9.5 behaviour.