### PR TITLE
Expose postgres comments to table and columns

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -230,7 +230,7 @@ func test_Table(t *testing.T) {
 		"character_maximum_length",
 		"character_set_catalog",
 		"column_default",
-		"comment"
+		"comment",
 	}
 
 	assert.Equal(t, nil, err)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -206,7 +206,7 @@ func test_Objects(t *testing.T) {
 	}
 
 	assert.Equal(t, nil, err)
-	assert.Equal(t, []string{"schema", "name", "type", "owner"}, res.Columns)
+	assert.Equal(t, []string{"schema", "name", "type", "owner", "comment"}, res.Columns)
 	assert.Equal(t, []string{"public"}, mapKeys(objects))
 	assert.Equal(t, tables, objects["public"].Tables)
 	assert.Equal(t, []string{"recent_shipments", "stock_view"}, objects["public"].Views)
@@ -230,6 +230,7 @@ func test_Table(t *testing.T) {
 		"character_maximum_length",
 		"character_set_catalog",
 		"column_default",
+		"comment"
 	}
 
 	assert.Equal(t, nil, err)

--- a/pkg/statements/sql.go
+++ b/pkg/statements/sql.go
@@ -82,7 +82,7 @@ SELECT
   character_maximum_length,
   character_set_catalog,
   column_default,
-  pg_catalog.col_description(concat($1, '.', $2)::regclass::oid, ordinal_position) as comment
+  pg_catalog.col_description(($1::text || '.' || $2::text)::regclass::oid, ordinal_position) as comment
 FROM
   information_schema.columns
 WHERE

--- a/pkg/statements/sql.go
+++ b/pkg/statements/sql.go
@@ -81,7 +81,8 @@ SELECT
   is_nullable,
   character_maximum_length,
   character_set_catalog,
-  column_default
+  column_default,
+  pg_catalog.col_description(concat($1, '.', $2)::regclass::oid, ordinal_position) as comment
 FROM
   information_schema.columns
 WHERE
@@ -120,7 +121,8 @@ SELECT
     WHEN 's' THEN 'special'
     WHEN 'f' THEN 'foreign_table'
   END as "type",
-  pg_catalog.pg_get_userbyid(c.relowner) as "owner"
+  pg_catalog.pg_get_userbyid(c.relowner) as "owner",
+  pg_catalog.obj_description(c.oid) as "comment"
 FROM
   pg_catalog.pg_class c
 LEFT JOIN


### PR DESCRIPTION
We use pgweb for individuals to query the database in a read-only manner, this allows them to discover the schema for those tables and columns which aren't self-explanatory.