### PR TITLE
Pretty-print JSON results by default

### DIFF
--- a/pkg/client/result.go
+++ b/pkg/client/result.go
@@ -108,7 +108,7 @@ func (res *Result) CSV() []byte {
 }
 
 func (res *Result) JSON() []byte {
-	data, _ := json.Marshal(res.Format())
+	data, _ := json.MarshalIndent(res.Format(), "", " ")
 	return data
 }
 

--- a/pkg/client/result.go
+++ b/pkg/client/result.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/sosedoff/pgweb/pkg/command"
 )
 
 type Row []interface{}
@@ -108,7 +110,13 @@ func (res *Result) CSV() []byte {
 }
 
 func (res *Result) JSON() []byte {
-	data, _ := json.MarshalIndent(res.Format(), "", " ")
+	var data []byte
+
+	if command.Opts.EnablePrettyJson {
+		data, _ = json.MarshalIndent(res.Format(), "", " ")
+	} else {
+		data, _ = json.Marshal(res.Format())
+	}
 	return data
 }
 

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -8,26 +8,27 @@ import (
 )
 
 type Options struct {
-	Version      bool   `short:"v" long:"version" description:"Print version"`
-	Debug        bool   `short:"d" long:"debug" description:"Enable debugging mode" default:"false"`
-	Url          string `long:"url" description:"Database connection string"`
-	Host         string `long:"host" description:"Server hostname or IP"`
-	Port         int    `long:"port" description:"Server port" default:"5432"`
-	User         string `long:"user" description:"Database user"`
-	Pass         string `long:"pass" description:"Password for user"`
-	DbName       string `long:"db" description:"Database name"`
-	Ssl          string `long:"ssl" description:"SSL option"`
-	HttpHost     string `long:"bind" description:"HTTP server host" default:"localhost"`
-	HttpPort     uint   `long:"listen" description:"HTTP server listen port" default:"8081"`
-	AuthUser     string `long:"auth-user" description:"HTTP basic auth user"`
-	AuthPass     string `long:"auth-pass" description:"HTTP basic auth password"`
-	SkipOpen     bool   `short:"s" long:"skip-open" description:"Skip browser open on start"`
-	Sessions     bool   `long:"sessions" description:"Enable multiple database sessions" default:"false"`
-	Prefix       string `long:"prefix" description:"Add a url prefix"`
-	ReadOnly     bool   `long:"readonly" description:"Run database connection in readonly mode"`
-	LockSession  bool   `long:"lock-session" description:"Lock session to a single database connection" default:"false"`
-	Bookmark     string `short:"b" long:"bookmark" description:"Bookmark to use for connection. Bookmark files are stored under $HOME/.pgweb/bookmarks/*.toml" default:""`
-	BookmarksDir string `long:"bookmarks-dir" description:"Overrides default directory for bookmark files to search" default:""`
+	Version          bool   `short:"v" long:"version" description:"Print version"`
+	Debug            bool   `short:"d" long:"debug" description:"Enable debugging mode" default:"false"`
+	Url              string `long:"url" description:"Database connection string"`
+	Host             string `long:"host" description:"Server hostname or IP"`
+	Port             int    `long:"port" description:"Server port" default:"5432"`
+	User             string `long:"user" description:"Database user"`
+	Pass             string `long:"pass" description:"Password for user"`
+	DbName           string `long:"db" description:"Database name"`
+	Ssl              string `long:"ssl" description:"SSL option"`
+	HttpHost         string `long:"bind" description:"HTTP server host" default:"localhost"`
+	HttpPort         uint   `long:"listen" description:"HTTP server listen port" default:"8081"`
+	AuthUser         string `long:"auth-user" description:"HTTP basic auth user"`
+	AuthPass         string `long:"auth-pass" description:"HTTP basic auth password"`
+	SkipOpen         bool   `short:"s" long:"skip-open" description:"Skip browser open on start"`
+	Sessions         bool   `long:"sessions" description:"Enable multiple database sessions" default:"false"`
+	Prefix           string `long:"prefix" description:"Add a url prefix"`
+	ReadOnly         bool   `long:"readonly" description:"Run database connection in readonly mode"`
+	LockSession      bool   `long:"lock-session" description:"Lock session to a single database connection" default:"false"`
+	Bookmark         string `short:"b" long:"bookmark" description:"Bookmark to use for connection. Bookmark files are stored under $HOME/.pgweb/bookmarks/*.toml" default:""`
+	BookmarksDir     string `long:"bookmarks-dir" description:"Overrides default directory for bookmark files to search" default:""`
+	EnablePrettyJson bool   `long:"feature-pretty-json" description:"Format JSON output" default:"true"`
 }
 
 var Opts Options


### PR DESCRIPTION
This is an experimental feature. Basically the results downloaded in JSON format will be
automatically pretty-printed. I'm thinking for raw results we can support an url param, like `/api/query?format=json&raw=1`.

Performance implications are pretty small: pretty print vs regular export had only 700ms difference on 50 mb data dump. With that, the output could be used for something like #249.

