### PR TITLE
Trigger CI failure if bindata contains any dev links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ go:
 env:
   - GO15VENDOREXPERIMENT=1
 
+before_install:
+  - ./script/check_assets.sh
+
 install:
   - make setup
 

--- a/script/check_assets.sh
+++ b/script/check_assets.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if grep -q 'go/src/github.com/sosedoff/pgweb' ./pkg/data/bindata.go
+then
+  echo "=========================================================="
+  echo "ERROR: Bindata contains development references to assets!"
+  echo "Fix with 'make assets' and commit the change."
+  echo "=========================================================="
+  exit 1
+fi

--- a/script/test_all.sh
+++ b/script/test_all.sh
@@ -15,6 +15,15 @@ export PGPASSWORD=""
 export PGDATABASE="booktown"
 export PGPORT="15432"
 
+if grep -q 'go/src/github.com/sosedoff/pgweb' ./pkg/data/bindata.go
+then
+  echo "=========================================================="
+  echo "ERROR: Bindata contains development references to assets!"
+  echo "Fix with 'make assets' and commit the change."
+  echo "=========================================================="
+  exit 1
+fi
+
 for i in {1..6}
 do
   export PGVERSION="9.$i"

--- a/script/test_all.sh
+++ b/script/test_all.sh
@@ -15,15 +15,6 @@ export PGPASSWORD=""
 export PGDATABASE="booktown"
 export PGPORT="15432"
 
-if grep -q 'go/src/github.com/sosedoff/pgweb' ./pkg/data/bindata.go
-then
-  echo "=========================================================="
-  echo "ERROR: Bindata contains development references to assets!"
-  echo "Fix with 'make assets' and commit the change."
-  echo "=========================================================="
-  exit 1
-fi
-
 for i in {1..6}
 do
   export PGVERSION="9.$i"


### PR DESCRIPTION
Sometimes dev assets sneak into master, this CI guard should trigger failures if there were any dev links found in the `bindata.go` file