### PR TITLE
FIx TCP listener test flakyness

### DIFF
--- a/pkg/connection/port_test.go
+++ b/pkg/connection/port_test.go
@@ -57,11 +57,14 @@ func Test_getAvailablePort(t *testing.T) {
 	defer serv.Close()
 
 	go func() {
-		conn, err := serv.Accept()
-		if err == nil {
-			conn.Close()
+		for {
+			conn, err := serv.Accept()
+			if err == nil {
+				conn.Close()
+				serv.Close()
+				return
+			}
 		}
-		serv.Close()
 	}()
 
 	port, err = AvailablePort(30000, 0)

--- a/pkg/connection/port_test.go
+++ b/pkg/connection/port_test.go
@@ -59,11 +59,12 @@ func Test_getAvailablePort(t *testing.T) {
 	go func() {
 		for {
 			conn, err := serv.Accept()
-			if err == nil {
-				conn.Close()
+			if err != nil {
+				fmt.Println(os.Stderr, "Server accept error:", err)
 				serv.Close()
 				return
 			}
+			conn.Close()
 		}
 	}()
 

--- a/pkg/connection/port_test.go
+++ b/pkg/connection/port_test.go
@@ -57,12 +57,11 @@ func Test_getAvailablePort(t *testing.T) {
 	defer serv.Close()
 
 	go func() {
-		for {
-			conn, err := serv.Accept()
-			if err == nil {
-				conn.Close()
-			}
+		conn, err := serv.Accept()
+		if err == nil {
+			conn.Close()
 		}
+		serv.Close()
 	}()
 
 	port, err = AvailablePort(30000, 0)


### PR DESCRIPTION
Close the listener socket as soon as we've got the connection accepted.