### PR TITLE
CockroachDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pgweb --host localhost --user myuser --db mydb
 Connection URL scheme is also supported:
 
 ```
-pgweb --url postgres://user:password@host:port/database?sslmode=[mode]
+pgweb --url (postgres|cockroach)://user:password@host:port/database?sslmode=[mode]
 ```
 
 ### Multiple database sessions

--- a/pkg/bookmarks/bookmarks.go
+++ b/pkg/bookmarks/bookmarks.go
@@ -20,6 +20,7 @@ type Bookmark struct {
 	User     string          `json:"user"`     // Database user
 	Password string          `json:"password"` // User password
 	Database string          `json:"database"` // Database name
+	Mode     string          `json:"mode"`     // Database mode
 	Ssl      string          `json:"ssl"`      // Connection SSL mode
 	Ssh      *shared.SSHInfo `json:"ssh"`      // SSH tunnel config
 }
@@ -36,6 +37,7 @@ func (b Bookmark) ConvertToOptions() command.Options {
 		User:   b.User,
 		Pass:   b.Password,
 		DbName: b.Database,
+		Mode:   b.Mode,
 		Ssl:    b.Ssl,
 	}
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -48,8 +48,12 @@ func initClientUsingBookmark(bookmarkPath, bookmarkName string) (*client.Client,
 	if !bookmark.SSHInfoIsEmpty() {
 		ssh = bookmark.Ssh
 	}
-
-	return client.NewFromUrl(connStr, ssh)
+	isCockroachDb := false
+	if strings.Contains( connStr, "cockroach") {
+		isCockroachDb = true
+		connStr = strings.Replace( connStr, "cockroach", "postgres", 1)
+	}
+	return client.NewFromUrl(connStr, ssh, isCockroachDb)
 }
 
 func initClient() {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -110,7 +110,7 @@ func setup() {
 
 func setupClient() {
 	url := fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, serverDatabase)
-	testClient, _ = NewFromUrl(url, nil)
+	testClient, _ = NewFromUrl(url, nil, false)
 }
 
 func teardownClient() {
@@ -135,7 +135,7 @@ func teardown() {
 
 func test_NewClientFromUrl(t *testing.T) {
 	url := fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, serverDatabase)
-	client, err := NewFromUrl(url, nil)
+	client, err := NewFromUrl(url, nil, false)
 
 	if err != nil {
 		defer client.Close()
@@ -147,7 +147,7 @@ func test_NewClientFromUrl(t *testing.T) {
 
 func test_NewClientFromUrl2(t *testing.T) {
 	url := fmt.Sprintf("postgresql://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, serverDatabase)
-	client, err := NewFromUrl(url, nil)
+	client, err := NewFromUrl(url, nil, false)
 
 	if err != nil {
 		defer client.Close()
@@ -357,7 +357,7 @@ func test_HistoryError(t *testing.T) {
 
 func test_HistoryUniqueness(t *testing.T) {
 	url := fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, serverDatabase)
-	client, _ := NewFromUrl(url, nil)
+	client, _ := NewFromUrl(url, nil, false)
 
 	client.Query("SELECT * FROM books WHERE id = 1")
 	client.Query("SELECT * FROM books WHERE id = 1")
@@ -368,7 +368,7 @@ func test_HistoryUniqueness(t *testing.T) {
 
 func test_ReadOnlyMode(t *testing.T) {
 	url := fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, serverDatabase)
-	client, _ := NewFromUrl(url, nil)
+	client, _ := NewFromUrl(url, nil, false)
 
 	err := client.SetReadOnlyMode()
 	assert.Equal(t, nil, err)

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -17,6 +17,7 @@ type Options struct {
 	User                         string `long:"user" description:"Database user"`
 	Pass                         string `long:"pass" description:"Password for user"`
 	DbName                       string `long:"db" description:"Database name"`
+	Mode                         string `long:"mode" description:"Database mode (postgresql, cockroachdb)" default:"postgresql"`
 	Ssl                          string `long:"ssl" description:"SSL option"`
 	HttpHost                     string `long:"bind" description:"HTTP server host" default:"localhost"`
 	HttpPort                     uint   `long:"listen" description:"HTTP server listen port" default:"8081"`

--- a/pkg/connection/connection_string.go
+++ b/pkg/connection/connection_string.go
@@ -29,8 +29,10 @@ func FormatUrl(opts command.Options) (string, error) {
 	url := opts.Url
 
 	// Make sure to only accept urls in a standard format
-	if !strings.HasPrefix(url, "postgres://") && !strings.HasPrefix(url, "postgresql://") {
-		return "", errors.New("Invalid URL. Valid format: postgres://user:password@host:port/db?sslmode=mode")
+	validPrefix :=  ( strings.HasPrefix(url, "postgres://") || strings.HasPrefix(url, "cockroach://") )
+	
+	if !validPrefix {
+		return "", errors.New("Invalid URL. Valid format: (postgres|cockroach)://user:password@host:port/db?sslmode=mode")
 	}
 
 	// Special handling for local connections

--- a/pkg/connection/connection_string_test.go
+++ b/pkg/connection/connection_string_test.go
@@ -22,7 +22,7 @@ func Test_Invalid_Url(t *testing.T) {
 
 		assert.Equal(t, "", str)
 		assert.Error(t, err)
-		assert.Equal(t, "Invalid URL. Valid format: postgres://user:password@host:port/db?sslmode=mode", err.Error())
+		assert.Equal(t, "Invalid URL. Valid format: (postgres|cockroach)://user:password@host:port/db?sslmode=mode", err.Error())
 	}
 }
 

--- a/pkg/statements/sql.go
+++ b/pkg/statements/sql.go
@@ -1,149 +1,46 @@
 package statements
 
-const (
-	Databases = `
-SELECT
-  datname
-FROM
-  pg_database
-WHERE
-  NOT datistemplate
-ORDER BY
-  datname ASC`
-
-	// ---------------------------------------------------------------------------
-
-	Schemas = `
-SELECT
-  schema_name
-FROM
-  information_schema.schemata
-ORDER BY
-  schema_name ASC`
-
-	// ---------------------------------------------------------------------------
-
-	Info = `
-SELECT
-  session_user,
-  current_user,
-  current_database(),
-  current_schemas(false),
-  inet_client_addr(),
-  inet_client_port(),
-  inet_server_addr(),
-  inet_server_port(),
-  version()`
-
-	// ---------------------------------------------------------------------------
-
-	TableIndexes = `
-SELECT
-  indexname, indexdef
-FROM
-  pg_indexes
-WHERE
-  schemaname = $1 AND
-  tablename = $2`
-
-	// ---------------------------------------------------------------------------
-
-	TableConstraints = `
-SELECT
-  conname as name,
-  pg_get_constraintdef(c.oid, true) as definition
-FROM
-  pg_constraint c
-JOIN
-  pg_namespace n ON n.oid = c.connamespace
-JOIN
-  pg_class cl ON cl.oid = c.conrelid
-WHERE
-  n.nspname = $1 AND
-  relname = $2
-ORDER BY
-  contype desc`
-
-	// ---------------------------------------------------------------------------
-
-	TableInfo = `
-SELECT
-  pg_size_pretty(pg_table_size($1)) AS data_size,
-  pg_size_pretty(pg_indexes_size($1)) AS index_size,
-  pg_size_pretty(pg_total_relation_size($1)) AS total_size,
-  (SELECT reltuples FROM pg_class WHERE oid = $1::regclass) AS rows_count`
-
-	// ---------------------------------------------------------------------------
-
-	TableSchema = `
-SELECT
-  column_name,
-  data_type,
-  is_nullable,
-  character_maximum_length,
-  character_set_catalog,
-  column_default,
-  pg_catalog.col_description(($1::text || '.' || $2::text)::regclass::oid, ordinal_position) as comment
-FROM
-  information_schema.columns
-WHERE
-  table_schema = $1 AND
-  table_name = $2`
-
-	// ---------------------------------------------------------------------------
-
-	MaterializedView = `
-SELECT 
-  attname as column_name, 
-  atttypid::regtype AS data_type,
-  (case when attnotnull IS TRUE then 'NO' else 'YES' end) as is_nullable,
-  null as character_maximum_length,
-  null as character_set_catalog,
-  null as column_default
-FROM
-  pg_attribute
-WHERE
-  attrelid = $1::regclass AND
-  attnum > 0 AND
-  NOT attisdropped`
-
-	// ---------------------------------------------------------------------------
-
-	Objects = `
-SELECT
-  n.nspname as "schema",
-  c.relname as "name",
-  CASE c.relkind
-    WHEN 'r' THEN 'table'
-    WHEN 'v' THEN 'view'
-    WHEN 'm' THEN 'materialized_view'
-    WHEN 'i' THEN 'index'
-    WHEN 'S' THEN 'sequence'
-    WHEN 's' THEN 'special'
-    WHEN 'f' THEN 'foreign_table'
-  END as "type",
-  pg_catalog.pg_get_userbyid(c.relowner) as "owner",
-  pg_catalog.obj_description(c.oid) as "comment"
-FROM
-  pg_catalog.pg_class c
-LEFT JOIN
-  pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-WHERE
-  c.relkind IN ('r','v','m','S','s','') AND
-  n.nspname !~ '^pg_toast' AND 
-  n.nspname NOT IN ('information_schema', 'pg_catalog') AND
-  has_schema_privilege(n.nspname, 'USAGE')
-ORDER BY 1, 2`
+import (
+	"errors"
 )
+
+// DatabaseSql is the sql queries interface
+type DatabaseDialect struct {
+	Databases *string
+	Schemas *string
+	Info * string
+	TableIndexes *string
+	TableConstraints *string
+	TableInfo *string
+	TableSchema *string
+	MaterializedView *string
+	Objects *string
+	Activity *map[string]string
+	Provider string
+}
+
 
 var (
-	Activity = map[string]string{
-		"default": "SELECT * FROM pg_stat_activity",
-		"9.1":     "SELECT datname, current_query, waiting, query_start, procpid as pid, datid, application_name, client_addr FROM pg_stat_activity",
-		"9.2":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
-		"9.3":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
-		"9.4":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
-		"9.5":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
-		"9.6":     "SELECT datname, query, state, wait_event, wait_event_type, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
-	}
+	sqlDialects  = make(map[string]*DatabaseDialect)
+	errorAlreadyRegistered = errors.New("Dialect already registered")
+	errorNotFound = errors.New("Dialect not found")
 )
+
+// RegisterDialect register new available sql dialect
+func RegisterDialect( name string, dialect* DatabaseDialect ) error {
+	if _, ok := sqlDialects[name]; ok {
+		return errorAlreadyRegistered
+	}
+	sqlDialects[name] = dialect
+	return nil
+}
+
+
+// FindDialect search dialect in registered dialect list
+func FindDialect( name string ) (*DatabaseDialect, error) {
+	if dialect, ok := sqlDialects[name]; !ok {
+		return nil,errorNotFound
+	} else {
+		return dialect, nil
+	}
+}

--- a/pkg/statements/sql_cockroach.go
+++ b/pkg/statements/sql_cockroach.go
@@ -1,0 +1,131 @@
+package statements
+
+var (
+	
+	// ---------------------------------------------------------------------------
+	DatabasesCockroach = `
+		SELECT
+  			datname
+		FROM
+  			pg_database
+		WHERE
+  			NOT datistemplate
+		ORDER BY
+  			datname ASC`
+  			
+	// ---------------------------------------------------------------------------
+	SchemasCockroach = `
+		SELECT
+  			schema_name
+		FROM
+  			information_schema.schemata
+		ORDER BY
+  			schema_name ASC`
+	
+	// ---------------------------------------------------------------------------
+	InfoCockroach = `
+		SELECT
+  			session_user,
+  			current_user,
+  			current_database(),
+  			current_schemas(false),
+  			'',
+  			'',
+  			'',
+  			'',
+  			version()`
+	// ---------------------------------------------------------------------------
+	TableIndexesCockroach = "SHOW INDEX FROM $1.$2";
+	// ---------------------------------------------------------------------------
+	TableConstraintsCockroach = `SHOW CONSTRAINTS FROM $1.$2`
+	
+	// ---------------------------------------------------------------------------
+	TableInfoCockroach = `
+		SELECT
+			0 AS data_size,
+  	   		0 AS index_size,
+			0 AS total_size,
+			( SELECT count(*) FROM $1 AS rows_count )`
+	// ---------------------------------------------------------------------------
+	TableSchemaCockroach = `
+		SELECT
+  			column_name,
+  			data_type,
+  			is_nullable,
+  			character_maximum_length,
+  			column_default
+		FROM
+  			information_schema.columns
+		WHERE
+  			table_schema = $1 AND
+  			table_name = $2`
+	// ---------------------------------------------------------------------------
+	MaterializedViewCockroach = `
+		SELECT
+  			attname as column_name,
+  			atttypid::regtype AS data_type,
+  			(case when attnotnull IS TRUE then 'NO' else 'YES' end) as is_nullable,
+  			null as character_maximum_length,
+  			null as character_set_catalog,
+  			null as column_default
+		FROM
+  			pg_attribute
+		WHERE
+  			attrelid = $1::regclass AND
+  			attnum > 0 AND
+  			NOT attisdropped`
+	// ---------------------------------------------------------------------------
+	ObjectsCockroach = `
+	    SELECT
+  			n.nspname as "schema",
+  			c.relname as "name",
+  		CASE c.relkind
+		WHEN 'r' THEN 'table'
+    	WHEN 'v' THEN 'view'
+    	WHEN 'm' THEN 'materialized_view'
+    	WHEN 'i' THEN 'index'
+    	WHEN 'S' THEN 'sequence'
+    	WHEN 's' THEN 'special'
+    	WHEN 'f' THEN 'foreign_table'
+  		END as "type",
+  			pg_catalog.pg_get_userbyid(c.relowner) as "owner",
+  			pg_catalog.obj_description(c.oid) as "comment"
+  		FROM
+  			pg_catalog.pg_class c
+		LEFT JOIN
+  			pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+  		left join
+  			information_schema.table_privileges i on i.table_name = c.relname and
+  			i.table_schema = n.nspname and i.grantee = current_user
+		WHERE
+  			c.relkind IN ('r','v','m','S','s','') AND
+  			n.nspname !~ '^pg_toast' AND
+  			n.nspname NOT IN ('information_schema', 'pg_catalog')
+  			and ( current_user() = 'root' or i.privilege_type in ('ALL','SELECT') )
+		ORDER BY 1, 2`
+		
+	// ---------------------------------------------------------------------------
+	ActivityCockroach = map[string]string{
+		"default": `SHOW CLUSTER QUERIES`,
+	}
+
+
+	CockroachDialect = &DatabaseDialect {
+&DatabasesCockroach,
+&SchemasCockroach,
+&InfoCockroach,
+&TableIndexesCockroach,
+&TableConstraintsCockroach,
+&TableInfoCockroach,
+&TableSchemaCockroach,
+&MaterializedViewCockroach,
+&ObjectsCockroach,
+&ActivityCockroach,
+"cockroach",
+}
+
+)
+
+func init() {
+	RegisterDialect("cockroach",CockroachDialect )
+}

--- a/pkg/statements/sql_cockroach.go
+++ b/pkg/statements/sql_cockroach.go
@@ -76,8 +76,8 @@ var (
   			NOT attisdropped`
 	// ---------------------------------------------------------------------------
 	ObjectsCockroach = `
-	    SELECT
-  			n.nspname as "schema",
+		SELECT
+			n.nspname as "schema",
   			c.relname as "name",
   		CASE c.relkind
 		WHEN 'r' THEN 'table'
@@ -94,14 +94,12 @@ var (
   			pg_catalog.pg_class c
 		LEFT JOIN
   			pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-  		left join
-  			information_schema.table_privileges i on i.table_name = c.relname and
-  			i.table_schema = n.nspname and i.grantee = current_user
 		WHERE
-  			c.relkind IN ('r','v','m','S','s','') AND
-  			n.nspname !~ '^pg_toast' AND
-  			n.nspname NOT IN ('information_schema', 'pg_catalog')
-  			and ( current_user() = 'root' or i.privilege_type in ('ALL','SELECT') )
+  			c.relkind IN ('r','v','m','S','s','')
+  			AND (
+  				  ( current_user() = 'root' and n.nspname NOT IN ('system', 'crdb_internal') ) OR
+  				  ( current_user() <> 'root' and n.nspname NOT IN ('information_schema', 'pg_catalog','system', 'crdb_internal') )
+  				)
 		ORDER BY 1, 2`
 		
 	// ---------------------------------------------------------------------------

--- a/pkg/statements/sql_postgres.go
+++ b/pkg/statements/sql_postgres.go
@@ -1,0 +1,155 @@
+package statements
+
+var (
+
+	// ---------------------------------------------------------------------------
+	DatabasesPostgres= `
+		SELECT
+  			datname
+		FROM
+  			pg_database
+		WHERE
+  			NOT datistemplate
+		ORDER BY
+  			datname ASC`
+	// ---------------------------------------------------------------------------
+	SchemasPostgres = `
+		SELECT
+  			schema_name
+		FROM
+  			information_schema.schemata
+		ORDER BY
+  			schema_name ASC`
+	// ---------------------------------------------------------------------------
+	InfoPostgres = `
+		SELECT
+  			session_user,
+  			current_user,
+  			current_database(),
+  			current_schemas(false),
+			inet_client_addr(),
+  			inet_client_port(),
+  			inet_server_addr(),
+  			inet_server_port(),
+  			version()`
+	// ---------------------------------------------------------------------------
+	TableIndexesPostgres = `
+		SELECT
+  			indexname, indexdef
+		FROM
+  			pg_indexes
+		WHERE
+  			schemaname = $1 AND
+  		tablename = $2`
+	// ---------------------------------------------------------------------------
+	TableConstraintsPostgres = `
+		SELECT
+  			conname as name,
+  			pg_get_constraintdef(c.oid, true) as definition
+		FROM
+  			pg_constraint c
+		JOIN
+  			pg_namespace n ON n.oid = c.connamespace
+		JOIN
+  			pg_class cl ON cl.oid = c.conrelid
+		WHERE
+  			n.nspname = $1 AND
+  			relname = $2
+		ORDER BY
+  			contype desc`
+	
+	// ---------------------------------------------------------------------------
+	TableInfoPostgres = `
+		SELECT
+  			pg_size_pretty(pg_table_size($1)) AS data_size,
+  			pg_size_pretty(pg_indexes_size($1)) AS index_size,
+  			pg_size_pretty(pg_total_relation_size($1)) AS total_size,
+  			(SELECT reltuples FROM pg_class WHERE oid = $1::regclass) AS rows_count`
+	
+	// ---------------------------------------------------------------------------
+	TableSchemaPostgres = `
+		SELECT
+  			column_name,
+  			data_type,
+  			is_nullable,
+  			character_maximum_length,
+  			character_set_catalog,
+  			column_default,
+  			pg_catalog.col_description(($1::text || '.' || $2::text)::regclass::oid, ordinal_position) as comment
+		FROM
+  			information_schema.columns
+		WHERE
+  			table_schema = $1 AND
+  			table_name = $2`
+	// ---------------------------------------------------------------------------
+	MaterializedViewPostgres = `
+		SELECT
+  			attname as column_name,
+  			atttypid::regtype AS data_type,
+  			(case when attnotnull IS TRUE then 'NO' else 'YES' end) as is_nullable,
+  			null as character_maximum_length,
+  			null as character_set_catalog,
+  			null as column_default
+		FROM
+  			pg_attribute
+		WHERE
+  			attrelid = $1::regclass AND
+  			attnum > 0 AND
+  			NOT attisdropped`
+	// ---------------------------------------------------------------------------
+	
+	ObjectsPostgres = `
+		SELECT
+  			n.nspname as "schema",
+  			c.relname as "name",
+  		CASE c.relkind
+    		WHEN 'r' THEN 'table'
+    		WHEN 'v' THEN 'view'
+    		WHEN 'm' THEN 'materialized_view'
+    		WHEN 'i' THEN 'index'
+    		WHEN 'S' THEN 'sequence'
+    		WHEN 's' THEN 'special'
+    		WHEN 'f' THEN 'foreign_table'
+  		END as "type",
+  			pg_catalog.pg_get_userbyid(c.relowner) as "owner",
+  			pg_catalog.obj_description(c.oid) as "comment"
+		FROM
+  			pg_catalog.pg_class c
+			LEFT JOIN
+  			pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+		WHERE
+  			c.relkind IN ('r','v','m','S','s','') AND
+  			n.nspname !~ '^pg_toast' AND
+  			n.nspname NOT IN ('information_schema', 'pg_catalog')
+  			AND has_schema_privilege(n.nspname, 'USAGE')
+		ORDER BY 1, 2`
+	// ---------------------------------------------------------------------------
+	ActivityPostgres = map[string]string{
+		"default": "SELECT * FROM pg_stat_activity",
+		"9.1":     "SELECT datname, current_query, waiting, query_start, procpid as pid, datid, application_name, client_addr FROM pg_stat_activity",
+		"9.2":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
+		"9.3":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
+		"9.4":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
+		"9.5":     "SELECT datname, query, state, waiting, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
+		"9.6":     "SELECT datname, query, state, wait_event, wait_event_type, query_start, state_change, pid, datid, application_name, client_addr FROM pg_stat_activity",
+	}
+
+	PostgresDialect = &DatabaseDialect {
+		&DatabasesPostgres,
+		&SchemasPostgres,
+		&InfoPostgres,
+		&TableIndexesPostgres,
+		&TableConstraintsPostgres,
+		&TableInfoPostgres,
+		&TableSchemaPostgres,
+		&MaterializedViewPostgres,
+		&ObjectsPostgres,
+		&ActivityPostgres,
+		"postgres",
+	}
+
+)
+
+func init() {
+	RegisterDialect("postgres",PostgresDialect )
+}

--- a/static/index.html
+++ b/static/index.html
@@ -135,7 +135,7 @@
               <label>Enter server URL scheme</label>
               <input type="text" class="form-control" id="connection_url" name="url" autocomplete="off">
               <p class="help-block">
-                URL format: postgres://user:password@host:port/db?sslmode=mode<br/>
+                URL format: (postgres|cockroach)://user:password@host:port/db?sslmode=mode<br/>
                 Read more on PostgreSQL <a href="https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING" target="_blank">connection string format</a>.
               </p>
             </div>
@@ -182,15 +182,26 @@
           </div>
 
           <div class="form-group">
-            <label class="col-sm-3 control-label">SSL Mode</label>
+            <label class="col-sm-3 control-label">Mode</label>
             <div class="col-sm-9">
-              <select class="form-control" id="connection_ssl">
-                <option value="disable">disable</option>
-                <option value="require" selected="selected">require</option>
-                <option value="verify-full">verify-full</option>
+              <select class="form-control" id="connection_mode">
+                <option value="postgres" selected="selected">PostgreSQL</option>
+                <option value="cockroach">CockroachDB</option>
               </select>
             </div>
           </div>
+
+            <div class="form-group">
+                <label class="col-sm-3 control-label">SSL Mode</label>
+                <div class="col-sm-9">
+                    <select class="form-control" id="connection_ssl">
+                        <option value="disable">disable</option>
+                        <option value="require" selected="selected">require</option>
+                        <option value="verify-full">verify-full</option>
+                    </select>
+                </div>
+            </div>
+
         </div>
 
         <div class="connection-ssh-group">


### PR DESCRIPTION
## New
- Added database mode selection to login screen

## Warning
- Need regenerate bindata

## Limitations
- Tested with CockroachDB CCL v1.1.5
- Minimum version v.1.1.5
- Currently root user supported
- Login with none root user , require select role to pg_catalog tables
- Connection partial information, missing client network information
- Table information not supported ( later )

## Supports
- Structure view supported
- Indexes view supported
- Constraints view supported
- Query, Explain query supported
- History supported
- Activity showing cluster query states
- Activity query stop supported
- Rows and filtering supported

## Bookmarks
- Not tested