### PR TITLE
Fixes table not found errors when dealing with table names that have uppercase characters

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -203,7 +203,8 @@ func (client *Client) TableRowsCount(table string, opts RowsOptions) (*Result, e
 }
 
 func (client *Client) TableInfo(table string) (*Result, error) {
-	return client.query(statements.TableInfo, table)
+	schema, table := getSchemaAndTable(table)
+	return client.query(statements.TableInfo, fmt.Sprintf(`"%s"."%s"`, schema, table))
 }
 
 func (client *Client) TableIndexes(table string) (*Result, error) {

--- a/pkg/statements/sql.go
+++ b/pkg/statements/sql.go
@@ -83,7 +83,7 @@ SELECT
   character_maximum_length,
   character_set_catalog,
   column_default,
-  pg_catalog.col_description(($1::text || '.' || $2::text)::regclass::oid, ordinal_position) as comment
+  pg_catalog.col_description(('"' || $1::text || '"."' || $2::text || '"')::regclass::oid, ordinal_position) as comment
 FROM
   information_schema.columns
 WHERE

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -865,6 +865,14 @@ function bindCurrentDatabaseMenu() {
   });
 }
 
+function getQuotedSchemaTableName(table) {
+  if (typeof table === "string" && table.indexOf(".") > -1) {
+    var schemaTableComponents = table.split(".");
+    return ['"', schemaTableComponents[0], '"."', schemaTableComponents[1], '"'].join('');
+  }
+  return table;
+}
+
 function bindContextMenus() {
   bindTableHeaderMenu();
   bindCurrentDatabaseMenu();
@@ -878,7 +886,7 @@ function bindContextMenus() {
         scopes: "li.schema-table",
         onItem: function(context, e) {
           var el      = $(e.target);
-          var table   = $(context[0]).data("id");
+          var table   = getQuotedSchemaTableName($(context[0]).data("id"));
           var action  = el.data("action");
           performTableAction(table, action, el);
         }
@@ -891,7 +899,7 @@ function bindContextMenus() {
         scopes: "li.schema-view",
         onItem: function(context, e) {
           var el      = $(e.target);
-          var table   = $(context[0]).data("id");
+          var table   = getQuotedSchemaTableName($(context[0]).data("id"));
           var action  = el.data("action");
           performViewAction(table, action, el);
         }


### PR DESCRIPTION
fixes issue that generates an error message when getting table info/schema via tabs, truncating/deleting table, and exporting data for tables with uppercase letters via right click menu

fixes exporting Tables with uppercase letters #310
