### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ MAINTAINER Dan Sosedoff <dan.sosedoff@gmail.com>
 ENV PGWEB_VERSION 0.9.12
 
 RUN \
-  apk update && \
-  apk add --update ca-certificates openssl && \
+  apk add --no-cache ca-certificates openssl postgresql && \
   update-ca-certificates && \
   cd /tmp && \
   wget https://github.com/sosedoff/pgweb/releases/download/v$PGWEB_VERSION/pgweb_linux_amd64.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.6
-MAINTAINER Dan Sosedoff <dan.sosedoff@gmail.com>
+
+LABEL maintainer="Dan Sosedoff <dan.sosedoff@gmail.com>"
+
 
 ENV PGWEB_VERSION 0.9.12
 


### PR DESCRIPTION
* Changed MAINTAINER instruction to LABEL since MAINTAINER is deprecated. See https://docs.docker.com/engine/reference/builder/#maintainer-deprecated for more info.
* Removed `apk update`.
* Added `--no-cache` parameter. As of Alpine Linux 3.3 we can utilize the `--no-cache` option for apk. It allows us to install packages with an index that is updated and used on-the-fly and not cached locally. No need to run `apk update`, `apk add --update` and remove `/var/cache/apk/*` when done installing packages.
* Added postgres package so we can utilize pg_dump to dump tables and databases.