### PR TITLE
Check if pg_dump is available before running database export

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -472,6 +472,13 @@ func DataExport(c *gin.Context) {
 		Table: strings.TrimSpace(c.Request.FormValue("table")),
 	}
 
+	// If pg_dump is not available the following code will not show an error in browser.
+	// This is due to the headers being written first.
+	if !dump.CanExport() {
+		c.JSON(400, Error{"pg_dump is not found"})
+		return
+	}
+
 	formattedInfo := info.Format()[0]
 	filename := formattedInfo["current_database"].(string)
 	if dump.Table != "" {

--- a/pkg/client/dump.go
+++ b/pkg/client/dump.go
@@ -11,6 +11,11 @@ type Dump struct {
 	Table string
 }
 
+func (d *Dump) CanExport() bool {
+	err := exec.Command("pg_dump", "--version").Run()
+	return err == nil
+}
+
 func (d *Dump) Export(url string, writer io.Writer) error {
 	errOutput := bytes.NewBuffer(nil)
 

--- a/pkg/client/dump_test.go
+++ b/pkg/client/dump_test.go
@@ -24,8 +24,12 @@ func test_DumpExport(t *testing.T) {
 		os.Remove(savePath)
 	}()
 
-	// Test full db dump
 	dump := Dump{}
+
+	// Test for pg_dump presence
+	assert.True(t, dump.CanExport())
+
+	// Test full db dump
 	err = dump.Export(url, saveFile)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
In cases when pgweb is running in the docker container (sosedoff/pgweb) it's not possible
to export the database dump because `pg_dump` is not available in the image. The backend will 
render the JSON error message, but since the headers for the attachment are already written, browser
will simply show the error indicating that page can't be loaded with no good explanation.

This should fix the issue and print the correct message if the dump can't be generated. 