### PR TITLE
Make localhost to be a default db host

### DIFF
--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -12,7 +12,7 @@ type Options struct {
 	Version                      bool   `short:"v" long:"version" description:"Print version"`
 	Debug                        bool   `short:"d" long:"debug" description:"Enable debugging mode"`
 	Url                          string `long:"url" description:"Database connection string"`
-	Host                         string `long:"host" description:"Server hostname or IP"`
+	Host                         string `long:"host" description:"Server hostname or IP" default:"localhost"`
 	Port                         int    `long:"port" description:"Server port" default:"5432"`
 	User                         string `long:"user" description:"Database user"`
 	Pass                         string `long:"pass" description:"Password for user"`


### PR DESCRIPTION
This changes the default behavior to connect to localhost by default.
As a result it reduced the amount of CLI flags necessary to connect to a local database:

```
pgweb --db=mydb
```