### PR TITLE
Fix row estimation bug

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -237,8 +237,8 @@ func (client *Client) EstimatedTableRowsCount(table string, opts RowsOptions) (*
 }
 
 func (client *Client) TableRowsCount(table string, opts RowsOptions) (*Result, error) {
-	schema, table := getSchemaAndTable(table)
-	sql := fmt.Sprintf(`SELECT COUNT(1) FROM "%s"."%s"`, schema, table)
+	schema, tableName := getSchemaAndTable(table)
+	sql := fmt.Sprintf(`SELECT COUNT(1) FROM "%s"."%s"`, schema, tableName)
 
 	if opts.Where != "" {
 		sql += fmt.Sprintf(" WHERE %s", opts.Where)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -301,7 +301,7 @@ func testTableRowsCount(t *testing.T) {
 
 func testTableRowsCountWithLargeTable(t *testing.T) {
 	var count int64 = 100010
-	testClient.db.MustExec(`create table large_table as select s from generate_Series(1,100010) s;`)
+	testClient.db.MustExec(`CREATE TABLE large_table AS SELECT s FROM generate_Series(1,100010) s;`)
 	testClient.db.MustExec(`VACUUM large_table;`)
 	res, err := testClient.TableRowsCount("large_table", RowsOptions{})
 


### PR DESCRIPTION
The variable `table` is mutated from `schema.tablename` to `tablename`
before being passed to other functions, which try to parse the schema
from the name. This results in schema name being `public` because it's
missing from the given table name.