### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: pgweb
+version: '1.0'
+summary: Cross-platform client for PostgreSQL databases  
+description: |
+  Cross-platform client for PostgreSQL databases. 
+grade: stable
+confinement: strict
+base: core18
+parts:
+  pgweb:
+    plugin: go
+    source: https://github.com/sosedoff/pgweb.git
+    go-importpath: github.com/sosedoff/pgweb
+    build-packages:
+      - build-essential
+apps:
+  pgweb:
+    command: bin/pgweb
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind


### PR DESCRIPTION
Hi Dan, following up on what we discussed, the exact details on how to publish the snap.

1. Install snapcraft & build snap

snap install snapcraft --classic --beta
git clone https://github.com/igorljubuncic/pgweb.git
cd pgweb
git checkout add-snapcraft
snapcraft

This command will generate a <pgweb-version>.snap file, something like pgweb_1.0_amd64.snap.

2. Test locally

This snap can be installed and tested locally with:

snap install pgweb_1.0_amd64.snap --dangerous

The --dangerous flag is necessary because the app (snap) hasn’t gone through the snap store review process and is not signed.

Once installed, the pgweb command can be executed, e.g.: snap run pgweb

3. Register dev account and pgweb name in the store

https://snapcraft.io/account.

snapcraft login
snapcraft register

4. Upload snap to the store. We use channels for diff levels of risk/stability. Edge is as the name implies, usually built from master, stable for the most stable release, you can also use beta and candidate.

snapcraft push pgweb_1.0_amd64.snap --release edge

5. Install from store

snap install pgweb --edge

That's it. Let me know if you have any questions.