### PR TITLE
Fix SQL export filename

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	neturl "net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -481,10 +482,12 @@ func DataExport(c *gin.Context) {
 	if dump.Table != "" {
 		filename = filename + "_" + dump.Table
 	}
+	reg := regexp.MustCompile("[^._\\w]+")
+	cleanFilename := reg.ReplaceAllString(filename, "")
 
 	c.Header(
 		"Content-Disposition",
-		fmt.Sprintf(`attachment; filename="%s.sql.gz"`, filename),
+		fmt.Sprintf(`attachment; filename="%s.sql.gz"`, cleanFilename),
 	)
 
 	err = dump.Export(db.ConnectionString, c.Writer)


### PR DESCRIPTION
Hi,

The browser CSV export is a bit broken because the filename passed in headers was mangled. Example :
`Content-Disposition: attachment; filename="postgres_"schema"."table".sql.gz"`

This PR fixes this.