### PR TITLE
Upgrade alpine to 3.10 - fix SQL export on up-to-date Postgresql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.10
 LABEL maintainer="Dan Sosedoff <dan.sosedoff@gmail.com>"
 ENV PGWEB_VERSION 0.11.3
 

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ docker:
 docker-release:
 	docker build --no-cache -t $(DOCKER_RELEASE_TAG) .
 	docker tag $(DOCKER_RELEASE_TAG) $(DOCKER_LATEST_TAG)
+	docker images $(DOCKER_RELEASE_TAG)
 
 docker-push:
 	docker push $(DOCKER_RELEASE_TAG)


### PR DESCRIPTION
On up-to-date Postgresql (11), the current version of pgweb can't SQL export because of a version mismatch : 

>        Because pg_dump is used to transfer data to newer versions of PostgreSQL, the output of pg_dump can be expected to load
>        into PostgreSQL server versions newer than pg_dump's version.  pg_dump can also dump from PostgreSQL servers older than its
>        own version. (Currently, servers back to version 8.0 are supported.) However, pg_dump cannot dump from PostgreSQL servers
>        newer than its own major version; it will refuse to even try, rather than risk making an invalid dump. Also, it is not
>        guaranteed that pg_dump's output can be loaded into a server of an older major version — not even if the dump was taken
>        from a server of that version. Loading a dump file into an older server may require manual editing of the dump file to
>        remove syntax not understood by the older server. Use of the --quote-all-identifiers option is recommended in cross-version
>        cases, as it can prevent problems arising from varying reserved-word lists in different PostgreSQL versions.

Upgrading to alpine 3.10 (latest stable) makes Postgresql 11 available (and backward compatible to older Postresql).