### PR TITLE
Handle server connection message on Windows

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -94,7 +94,7 @@ func initClient() {
 				return
 			}
 			// Do not bail if local server is not running.
-			if strings.Contains(msg, "connection refused") {
+			if strings.Contains(msg, "connection refused") || strings.Contains(msg, "actively refused") {
 				fmt.Println("Error:", msg)
 				return
 			}


### PR DESCRIPTION
Windows can report a slightly different message depending on the firewall configuration. This modification catches that message.

macOS:
```
Pgweb v0.11.6 (git: 3e4e9c30c947ce1384c49e4257c9a3cc9dc97876) (go: go1.13.7)
Connecting to server...
Error: dial tcp 127.0.0.1:5432: connect: connection refused
Starting server...
```

Windows:
```
Pgweb v0.11.6 (git: 3e4e9c30c947ce1384c49e4257c9a3cc9dc97876) (go: go1.13.7)
Connecting to server...
Error: dial tcp [::1]:5432: connectex: No connection could be made because the target machine actively refused it.
```