### PR TITLE
Add arm64 v7 option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ release: clean assets
 	  -ldflags "-s -w -X github.com/sosedoff/pgweb/pkg/command.GitCommit=$(GIT_COMMIT) -X github.com/sosedoff/pgweb/pkg/command.BuildTime=$(BUILD_TIME) -X github.com/sosedoff/pgweb/pkg/command.GoVersion=$(GO_VERSION)" \
 		-o "./bin/pgweb_linux_arm_v5"
 
+	@echo "Building ARM64 binaries..."
+	GOOS=linux GOARCH=arm64 GOARM=7 go build \
+	  -ldflags "-s -w -X github.com/sosedoff/pgweb/pkg/command.GitCommit=$(GIT_COMMIT) -X github.com/sosedoff/pgweb/pkg/command.BuildTime=$(BUILD_TIME) -X github.com/sosedoff/pgweb/pkg/command.GoVersion=$(GO_VERSION)" \
+		-o "./bin/pgweb_linux_arm64_v7"
+
 	@echo "\nPackaging binaries...\n"
 	@./script/package.sh
 


### PR DESCRIPTION
Add build options for arm64. Tested on a raspberry pi4 8 gb running Raspberry Pi OS 64 bit.

Should Fix https://github.com/sosedoff/pgweb/issues/496

