### PR TITLE
Show empty schemes as well

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -80,7 +80,6 @@ func setup() {
 		"-p", serverPort,
 		serverDatabase,
 	).CombinedOutput()
-
 	if err != nil {
 		fmt.Println("Database creation failed:", string(out))
 		fmt.Println("Error:", err)
@@ -122,7 +121,6 @@ func teardown() {
 		"-p", serverPort,
 		serverDatabase,
 	).CombinedOutput()
-
 	if err != nil {
 		fmt.Println("Teardown error:", err)
 	}
@@ -131,7 +129,6 @@ func teardown() {
 func testNewClientFromUrl(t *testing.T) {
 	url := fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, serverDatabase)
 	client, err := NewFromUrl(url, nil)
-
 	if err != nil {
 		defer client.Close()
 	}
@@ -143,7 +140,6 @@ func testNewClientFromUrl(t *testing.T) {
 func testNewClientFromUrl2(t *testing.T) {
 	url := fmt.Sprintf("postgresql://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, serverDatabase)
 	client, err := NewFromUrl(url, nil)
-
 	if err != nil {
 		defer client.Close()
 	}
@@ -226,10 +222,7 @@ func testObjects(t *testing.T) {
 
 	assert.Equal(t, nil, err)
 	assert.Equal(t, []string{"schema", "name", "type", "owner", "comment"}, res.Columns)
-	_, ok := objects["public"]
-	if !ok {
-		t.Fail()
-	}
+	assert.Contains(t, objects, "public")
 	assert.Equal(t, tables, objects["public"].Tables)
 	assert.Equal(t, []string{"recent_shipments", "stock_view"}, objects["public"].Views)
 	assert.Equal(t, []string{"author_ids", "book_ids", "shipments_ship_id_seq", "subject_ids"}, objects["public"].Sequences)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -24,14 +24,6 @@ var (
 	serverDatabase string
 )
 
-func mapKeys(data map[string]*Objects) []string {
-	result := []string{}
-	for k, _ := range data {
-		result = append(result, k)
-	}
-	return result
-}
-
 func pgVersion() (int, int) {
 	var major, minor int
 	fmt.Sscanf(os.Getenv("PGVERSION"), "%d.%d", &major, &minor)
@@ -234,7 +226,10 @@ func testObjects(t *testing.T) {
 
 	assert.Equal(t, nil, err)
 	assert.Equal(t, []string{"schema", "name", "type", "owner", "comment"}, res.Columns)
-	assert.Equal(t, []string{"public"}, mapKeys(objects))
+	_, ok := objects["public"]
+	if !ok {
+		t.Fail()
+	}
 	assert.Equal(t, tables, objects["public"].Tables)
 	assert.Equal(t, []string{"recent_shipments", "stock_view"}, objects["public"].Views)
 	assert.Equal(t, []string{"author_ids", "book_ids", "shipments_ship_id_seq", "subject_ids"}, objects["public"].Sequences)

--- a/pkg/client/result.go
+++ b/pkg/client/result.go
@@ -135,9 +135,6 @@ func ObjectsFromResult(res *Result) map[string]*Objects {
 
 	for _, row := range res.Rows {
 		schema := row[0].(string)
-		name := row[1].(string)
-		object_type := row[2].(string)
-
 		if objects[schema] == nil {
 			objects[schema] = &Objects{
 				Tables:            []string{},
@@ -146,6 +143,12 @@ func ObjectsFromResult(res *Result) map[string]*Objects {
 				Sequences:         []string{},
 			}
 		}
+
+		if row[1] == nil || row[2] == nil {
+			continue
+		}
+		name := row[1].(string)
+		object_type := row[2].(string)
 
 		switch object_type {
 		case "table":

--- a/pkg/statements/sql.go
+++ b/pkg/statements/sql.go
@@ -111,8 +111,8 @@ WHERE
 	// ---------------------------------------------------------------------------
 
 	MaterializedView = `
-SELECT 
-  attname as column_name, 
+SELECT
+  attname as column_name,
   atttypid::regtype AS data_type,
   (case when attnotnull IS TRUE then 'NO' else 'YES' end) as is_nullable,
   null as character_maximum_length,
@@ -144,11 +144,11 @@ SELECT
   pg_catalog.obj_description(c.oid) as "comment"
 FROM
   pg_catalog.pg_class c
-LEFT JOIN
+FULL OUTER JOIN
   pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 WHERE
-  c.relkind IN ('r','v','m','S','s','') AND
-  n.nspname !~ '^pg_toast' AND 
+  (c.relkind IN ('r','v','m','S','s','') OR c.relkind is null) AND
+  n.nspname !~ '^pg_toast' AND
   n.nspname NOT IN ('information_schema', 'pg_catalog') AND
   has_schema_privilege(n.nspname, 'USAGE')
 ORDER BY 1, 2`


### PR DESCRIPTION
# What does this PR do?

Empty schemes are shown in the ui as well.

# Motivation

We are providing postgres databases to other developers inside the Daimler Group and currently recommending pgweb as a client. We got the feedback that it is a little bit confusing that you do not see empty schemes in the ui. Users might only learn about schemes when trying to create them via SQL. I was wondering if there is any special reason for this behaviour?

Best regards

<sub>Mathias Zeller [mathias.zeller@daimler.com](mailto:mathia.zeller@daimler.com) Daimler TSS GmbH ([Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md))</sub>