### PR TITLE
fix: should be build time rather than runtime

### DIFF
--- a/pkg/command/version.go
+++ b/pkg/command/version.go
@@ -12,6 +12,6 @@ var (
 	// BuildTime contains the binary build time
 	BuildTime string
 
-	// GoVersion contains the Go runtime version
+	// GoVersion contains the build time Go version
 	GoVersion string
 )


### PR DESCRIPTION
From what I understand, `GoVersion` information reflects the build time go version rather than runtime.