### PR TITLE
try to reconnect when connection broke

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -411,8 +411,19 @@ func GetConnectionInfo(c *gin.Context) {
 	res, err := DB(c).Info()
 
 	if err != nil {
-		badRequest(c, err)
-		return
+		// try to reconnect automatically
+		cl, err := client.New()
+		if err != nil {
+			badRequest(c, err)
+			return
+		}
+
+		setClient(c, cl)
+		res, err = DB(c).Info()
+		if err != nil {
+			badRequest(c, err)
+			return
+		}
 	}
 
 	info := res.Format()[0]


### PR DESCRIPTION
Hi,

In our use case we configure pgweb to connect with a given database by setting `DATABASE_URL` in the environment.
This saves the end user the trouble of entering connection details in the UI.

After a while however it is possible that the connection to the database breaks, causing the UI to prompt for connection details.
Ideally this would not be needed since this pgweb instance is only meant to be used for a single database, for which connection details are available in the environment.

This PR introduces a change that allows automatically reconnecting in such cases.

remarks:
- I think that ideally the connect/disconnect buttons would get hidden if e.g. DATABASE_URL was configured, since this means we just want to run this pgweb for a single database - I haven't gone this far in this PR
- with this patch the user can disconnect (resulting in the connect screen being shown to them). if they next refresh the page they are again connected - this might be unexpected. (but no functionality is lost to them)

Would you be interested in this change, or is there anything I can do to make it (more) acceptable?