### PR TITLE
Serialize binary bytea cols into hex/base64

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -150,6 +150,12 @@ func initOptions() {
 		fmt.Println(readonlyWarning)
 	}
 
+	if options.BinaryCodec != "" {
+		if err := client.SetBinaryCodec(options.BinaryCodec); err != nil {
+			exitWithMessage(err.Error())
+		}
+	}
+
 	printVersion()
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -416,7 +416,7 @@ func (client *Client) query(query string, args ...interface{}) (*Result, error) 
 		}
 	}
 
-	result.PrepareBigints()
+	result.PostProcess()
 
 	return &result, nil
 }

--- a/pkg/client/codec.go
+++ b/pkg/client/codec.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+)
+
+const (
+	CodecNone   = "none"
+	CodecHex    = "hex"
+	CodecBase64 = "base64"
+)
+
+var (
+	// BinaryEncodingFormat specifies the default serialization format of binary data
+	BinaryCodec = CodecBase64
+)
+
+func SetBinaryCodec(codec string) error {
+	switch codec {
+	case CodecNone, CodecHex, CodecBase64:
+		BinaryCodec = codec
+	default:
+		return fmt.Errorf("invalid binary codec value: %v", codec)
+	}
+
+	return nil
+}
+
+func encodeBinaryData(data []byte) string {
+	switch BinaryCodec {
+	case CodecHex:
+		return hex.EncodeToString(data)
+	case CodecBase64:
+		return base64.StdEncoding.EncodeToString(data)
+	default:
+		return string(data)
+	}
+}

--- a/pkg/client/codec.go
+++ b/pkg/client/codec.go
@@ -22,7 +22,7 @@ func SetBinaryCodec(codec string) error {
 	case CodecNone, CodecHex, CodecBase64:
 		BinaryCodec = codec
 	default:
-		return fmt.Errorf("invalid binary codec value: %v", codec)
+		return fmt.Errorf("invalid binary codec: %v", codec)
 	}
 
 	return nil

--- a/pkg/client/codec.go
+++ b/pkg/client/codec.go
@@ -28,8 +28,8 @@ func SetBinaryCodec(codec string) error {
 	return nil
 }
 
-func encodeBinaryData(data []byte) string {
-	switch BinaryCodec {
+func encodeBinaryData(data []byte, codec string) string {
+	switch codec {
 	case CodecHex:
 		return hex.EncodeToString(data)
 	case CodecBase64:

--- a/pkg/client/codec_test.go
+++ b/pkg/client/codec_test.go
@@ -20,6 +20,11 @@ func TestSetBinaryCodec(t *testing.T) {
 
 	for _, ex := range examples {
 		t.Run(ex.input, func(t *testing.T) {
+			val := BinaryCodec
+			defer func() {
+				BinaryCodec = val
+			}()
+
 			assert.Equal(t, ex.err, SetBinaryCodec(ex.input))
 		})
 	}
@@ -38,8 +43,7 @@ func Test_encodeBinaryData(t *testing.T) {
 
 	for _, ex := range examples {
 		t.Run(ex.input, func(t *testing.T) {
-			SetBinaryCodec(ex.encoding)
-			assert.Equal(t, ex.expected, encodeBinaryData([]byte(ex.input)))
+			assert.Equal(t, ex.expected, encodeBinaryData([]byte(ex.input), ex.encoding))
 		})
 	}
 }

--- a/pkg/client/codec_test.go
+++ b/pkg/client/codec_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetBinaryCodec(t *testing.T) {
+	examples := []struct {
+		input string
+		err   error
+	}{
+		{input: CodecNone, err: nil},
+		{input: CodecBase64, err: nil},
+		{input: CodecHex, err: nil},
+		{input: "foobar", err: errors.New("invalid binary codec: foobar")},
+	}
+
+	for _, ex := range examples {
+		t.Run(ex.input, func(t *testing.T) {
+			assert.Equal(t, ex.err, SetBinaryCodec(ex.input))
+		})
+	}
+}
+
+func Test_encodeBinaryData(t *testing.T) {
+	examples := []struct {
+		input    string
+		expected string
+		encoding string
+	}{
+		{input: "hello world", expected: "hello world", encoding: CodecNone},
+		{input: "hello world", expected: "aGVsbG8gd29ybGQ=", encoding: CodecBase64},
+		{input: "hello world", expected: "68656c6c6f20776f726c64", encoding: CodecHex},
+	}
+
+	for _, ex := range examples {
+		t.Run(ex.input, func(t *testing.T) {
+			SetBinaryCodec(ex.encoding)
+			assert.Equal(t, ex.expected, encodeBinaryData([]byte(ex.input)))
+		})
+	}
+}

--- a/pkg/client/result.go
+++ b/pkg/client/result.go
@@ -3,7 +3,6 @@ package client
 import (
 	"bytes"
 	"encoding/csv"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -62,7 +61,7 @@ func (res *Result) PostProcess() {
 				}
 			case string:
 				if hasBinary(val, 8) {
-					res.Rows[i][j] = hex.EncodeToString([]byte(val))
+					res.Rows[i][j] = encodeBinaryData([]byte(val))
 				}
 			}
 		}

--- a/pkg/client/result.go
+++ b/pkg/client/result.go
@@ -60,8 +60,8 @@ func (res *Result) PostProcess() {
 					res.Rows[i][j] = strconv.FormatFloat(val, 'e', -1, 64)
 				}
 			case string:
-				if hasBinary(val, 8) {
-					res.Rows[i][j] = encodeBinaryData([]byte(val))
+				if hasBinary(val, 8) && BinaryCodec != CodecNone {
+					res.Rows[i][j] = encodeBinaryData([]byte(val), BinaryCodec)
 				}
 			}
 		}

--- a/pkg/client/result_test.go
+++ b/pkg/client/result_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_PrepareBigints(t *testing.T) {
+func Test_PostProcess(t *testing.T) {
 	result := Result{
 		Columns: []string{"value"},
 		Rows: []Row{
@@ -19,7 +19,7 @@ func Test_PrepareBigints(t *testing.T) {
 		},
 	}
 
-	result.PrepareBigints()
+	result.PostProcess()
 
 	assert.Equal(t, 1234, result.Rows[0][0])
 	assert.Equal(t, "9223372036854775807", result.Rows[1][0])

--- a/pkg/client/result_test.go
+++ b/pkg/client/result_test.go
@@ -35,7 +35,7 @@ func TestPostProcess(t *testing.T) {
 			Rows: []Row{
 				{"text value"},
 				{"text with symbols !@#$%"},
-				{[]byte{10, 11, 12, 13}},
+				{string([]byte{10, 11, 12, 13})},
 			},
 		}
 
@@ -43,7 +43,7 @@ func TestPostProcess(t *testing.T) {
 
 		assert.Equal(t, "text value", result.Rows[0][0])
 		assert.Equal(t, "text with symbols !@#$%", result.Rows[1][0])
-		assert.Equal(t, "text value", result.Rows[2][0])
+		assert.Equal(t, "CgsMDQ==", result.Rows[2][0])
 	})
 }
 

--- a/pkg/client/result_test.go
+++ b/pkg/client/result_test.go
@@ -7,33 +7,52 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_PostProcess(t *testing.T) {
-	result := Result{
-		Columns: []string{"value"},
-		Rows: []Row{
-			Row{int(1234)},
-			Row{int64(9223372036854775807)},
-			Row{int64(-9223372036854775808)},
-			Row{float64(9223372036854775808.9223372036854775808)},
-			Row{float64(999999999999999.9)},
-		},
-	}
+func TestPostProcess(t *testing.T) {
+	t.Run("large numbers", func(t *testing.T) {
+		result := Result{
+			Columns: []string{"value"},
+			Rows: []Row{
+				{int(1234)},
+				{int64(9223372036854775807)},
+				{int64(-9223372036854775808)},
+				{float64(9223372036854775808.9223372036854775808)},
+				{float64(999999999999999.9)},
+			},
+		}
 
-	result.PostProcess()
+		result.PostProcess()
 
-	assert.Equal(t, 1234, result.Rows[0][0])
-	assert.Equal(t, "9223372036854775807", result.Rows[1][0])
-	assert.Equal(t, "-9223372036854775808", result.Rows[2][0])
-	assert.Equal(t, "9.223372036854776e+18", result.Rows[3][0])
-	assert.Equal(t, "9.999999999999999e+14", result.Rows[4][0])
+		assert.Equal(t, 1234, result.Rows[0][0])
+		assert.Equal(t, "9223372036854775807", result.Rows[1][0])
+		assert.Equal(t, "-9223372036854775808", result.Rows[2][0])
+		assert.Equal(t, "9.223372036854776e+18", result.Rows[3][0])
+		assert.Equal(t, "9.999999999999999e+14", result.Rows[4][0])
+	})
+
+	t.Run("binary encoding", func(t *testing.T) {
+		result := Result{
+			Columns: []string{"data"},
+			Rows: []Row{
+				{"text value"},
+				{"text with symbols !@#$%"},
+				{[]byte{10, 11, 12, 13}},
+			},
+		}
+
+		result.PostProcess()
+
+		assert.Equal(t, "text value", result.Rows[0][0])
+		assert.Equal(t, "text with symbols !@#$%", result.Rows[1][0])
+		assert.Equal(t, "text value", result.Rows[2][0])
+	})
 }
 
-func Test_CSV(t *testing.T) {
+func TestCSV(t *testing.T) {
 	result := Result{
 		Columns: []string{"id", "name", "email"},
 		Rows: []Row{
-			Row{1, "John", "john@example.com"},
-			Row{2, "Bob", "bob@example.com"},
+			{1, "John", "john@example.com"},
+			{2, "Bob", "bob@example.com"},
 		},
 	}
 
@@ -43,12 +62,12 @@ func Test_CSV(t *testing.T) {
 	assert.Equal(t, expected, output)
 }
 
-func Test_JSON(t *testing.T) {
+func TestJSON(t *testing.T) {
 	result := Result{
 		Columns: []string{"id", "name", "email"},
 		Rows: []Row{
-			Row{1, "John", "john@example.com"},
-			Row{2, "Bob", "bob@example.com"},
+			{1, "John", "john@example.com"},
+			{2, "Bob", "bob@example.com"},
 		},
 	}
 

--- a/pkg/client/util.go
+++ b/pkg/client/util.go
@@ -31,3 +31,15 @@ func containsRestrictedKeywords(str string) bool {
 
 	return reRestrictedKeywords.MatchString(str)
 }
+
+func hasBinary(data string, checkLen int) bool {
+	for idx, chr := range data {
+		if int(chr) < 32 || int(chr) > 126 {
+			return true
+		}
+		if idx >= checkLen {
+			break
+		}
+	}
+	return false
+}

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -42,6 +42,7 @@ type Options struct {
 	ConnectionIdleTimeout        int    `long:"idle-timeout" description:"Set connection idle timeout in minutes" default:"180"`
 	Cors                         bool   `long:"cors" description:"Enable Cross-Origin Resource Sharing (CORS)"`
 	CorsOrigin                   string `long:"cors-origin" description:"Allowed CORS origins" default:"*"`
+	BinaryCodec                  string `long:"binary-codec" description:"Codec for binary data serialization"`
 }
 
 var Opts Options


### PR DESCRIPTION
This adds binary data serialization into base64 format by default, switchable to `none`, `hex`, `base64` via a new `--binary-codec=val` CLI option. 