### PR TITLE
Fix bug with UPDATE/DELETE and RETURNING clause

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -352,24 +352,34 @@ func (client *Client) query(query string, args ...interface{}) (*Result, error) 
 
 	action := strings.ToLower(strings.Split(query, " ")[0])
 	if action == "update" || action == "delete" {
-		res, err := client.db.Exec(query, args...)
-		if err != nil {
-			return nil, err
+		foundReturningClause := false
+		for _, word := range strings.Fields(query) {
+			if strings.ToLower(word) == "returning" {
+				foundReturningClause = true
+				break
+			}
 		}
 
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return nil, err
-		}
+		if !foundReturningClause {
+			res, err := client.db.Exec(query, args...)
+			if err != nil {
+				return nil, err
+			}
 
-		result := Result{
-			Columns: []string{"Rows Affected"},
-			Rows: []Row{
-				Row{affected},
-			},
-		}
+			affected, err := res.RowsAffected()
+			if err != nil {
+				return nil, err
+			}
 
-		return &result, nil
+			result := Result{
+				Columns: []string{"Rows Affected"},
+				Rows: []Row{
+					Row{affected},
+				},
+			}
+
+			return &result, nil
+		}
 	}
 
 	rows, err := client.db.Queryx(query, args...)


### PR DESCRIPTION
- Add a check if an update/delete query has a `RETURNING` clause. If it does, use `db.Queryx()` instead of `db.Exec()` to return the appropriate rows

This problem stems from the client having to use `Exec()` when no return value is expected (to get the number of rows affected by the update/delete), and `Queryx()` (to get the result of a `RETURNING` clause) when we expect rows to be returned. There is no clean way to differentiate the two cases to my knowledge, because (1) we have no way of accurately determining if a delete/update query will return any rows before running it, and (2) we cannot run both `Exec()` and `Queryx()` one after another because we cannot assume the updates/deletes are idempotent.

I recognize that this approach seems hacky, and is not 100% accurate (eg. it fails when a column is named "returning"). However, it seems to be the best way to me to tackle this issue. I appreciate any other insights regarding this.

Fixes #553 