### PR TITLE
Add netcat install in dockerfile to provide a way to healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM debian:buster-slim
 
 RUN \
   apt-get update && \
-  apt-get install -y ca-certificates openssl postgresql && \
+  apt-get install -y ca-certificates openssl postgresql netcat && \
   update-ca-certificates && \
   apt-get clean autoclean && \
   apt-get autoremove --yes && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "nc", "-vz", "127.0.0.1", "8081"]
+      interval: 5s
 
 volumes:
   data:


### PR DESCRIPTION
Today we can add healthcheck into docker compose to inspect if container is running file, but `debian:buster-slim` doesn't have a way to check by default.

I guess this is a good and light option to check if pgweb is listening and with this, provide health check.

What you think?