### PR TITLE
Include index size on the index list view

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -314,7 +314,7 @@ func testTableIndexes(t *testing.T) {
 	res, err := testClient.TableIndexes("books")
 
 	assert.Equal(t, nil, err)
-	assert.Equal(t, 2, len(res.Columns))
+	assert.Equal(t, []string{"index_name", "index_size", "index_definition"}, res.Columns)
 	assert.Equal(t, 2, len(res.Rows))
 }
 

--- a/pkg/statements/sql.go
+++ b/pkg/statements/sql.go
@@ -50,7 +50,9 @@ WHERE
 
 	TableIndexes = `
 SELECT
-  indexname, indexdef
+  indexname AS index_name,
+  pg_size_pretty(pg_table_size(indexname::regclass)) AS index_size,
+  indexdef AS index_definition
 FROM
   pg_indexes
 WHERE


### PR DESCRIPTION
This adds a new column for the index filesize in the table indexes page.