### PR TITLE
Enable dev assets mode with PGWEB_ASSETS_DEVMODE env var

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -63,7 +63,7 @@ func GetHome(prefix string) http.Handler {
 	if prefix != "" {
 		prefix = "/" + prefix
 	}
-	return http.StripPrefix(prefix, http.FileServer(http.FS(static.Static)))
+	return http.StripPrefix(prefix, static.GetHandler())
 }
 
 func GetAssets(prefix string) http.Handler {
@@ -72,7 +72,7 @@ func GetAssets(prefix string) http.Handler {
 	} else {
 		prefix = "/static/"
 	}
-	return http.StripPrefix(prefix, http.FileServer(http.FS(static.Static)))
+	return http.StripPrefix(prefix, static.GetHandler())
 }
 
 // GetSessions renders the number of active sessions

--- a/static/data.go
+++ b/static/data.go
@@ -1,7 +1,22 @@
 package static
 
-import "embed"
+import (
+	"embed"
+	"net/http"
+	"os"
+)
 
 //go:embed img/* js/* css/* fonts/*
 //go:embed index.html
-var Static embed.FS
+var assets embed.FS
+
+func GetFilesystem() http.FileSystem {
+	if os.Getenv("PGWEB_ASSETS_DEVMODE") == "1" {
+		return http.Dir("./static")
+	}
+	return http.FS(assets)
+}
+
+func GetHandler() http.Handler {
+	return http.FileServer(GetFilesystem())
+}


### PR DESCRIPTION
When env var is enabled, load assets directly from disk instead of embed.