### PR TITLE
Implement global query timeout option

### DIFF
--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -52,7 +52,7 @@ type Options struct {
 	Cors                         bool   `long:"cors" description:"Enable Cross-Origin Resource Sharing (CORS)"`
 	CorsOrigin                   string `long:"cors-origin" description:"Allowed CORS origins" default:"*"`
 	BinaryCodec                  string `long:"binary-codec" description:"Codec for binary data serialization, one of 'none', 'hex', 'base58', 'base64'" default:"none"`
-	QueryTimeout                 int    `long:"query-timeout" description:"Set global query execution timeout" default:"0"`
+	QueryTimeout                 int    `long:"query-timeout" description:"Set global query execution timeout in seconds" default:"0"`
 }
 
 var Opts Options

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -49,10 +49,10 @@ type Options struct {
 	ConnectHeaders               string `long:"connect-headers" description:"List of headers to pass to the connect backend"`
 	DisableConnectionIdleTimeout bool   `long:"no-idle-timeout" description:"Disable connection idle timeout"`
 	ConnectionIdleTimeout        int    `long:"idle-timeout" description:"Set connection idle timeout in minutes" default:"180"`
+	QueryTimeout                 int    `long:"query-timeout" description:"Set global query execution timeout in seconds" default:"0"`
 	Cors                         bool   `long:"cors" description:"Enable Cross-Origin Resource Sharing (CORS)"`
 	CorsOrigin                   string `long:"cors-origin" description:"Allowed CORS origins" default:"*"`
 	BinaryCodec                  string `long:"binary-codec" description:"Codec for binary data serialization, one of 'none', 'hex', 'base58', 'base64'" default:"none"`
-	QueryTimeout                 int    `long:"query-timeout" description:"Set global query execution timeout in seconds" default:"0"`
 }
 
 var Opts Options

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -52,6 +52,7 @@ type Options struct {
 	Cors                         bool   `long:"cors" description:"Enable Cross-Origin Resource Sharing (CORS)"`
 	CorsOrigin                   string `long:"cors-origin" description:"Allowed CORS origins" default:"*"`
 	BinaryCodec                  string `long:"binary-codec" description:"Codec for binary data serialization, one of 'none', 'hex', 'base58', 'base64'" default:"none"`
+	QueryTimeout                 int    `long:"query-timeout" description:"Set global query execution timeout" default:"0"`
 }
 
 var Opts Options


### PR DESCRIPTION
With `--query-timeout=N` every query that exceeds N seconds will be terminated. That includes any system queries to get objects, etc.