### PR TITLE
Request logging additions (request id, forwarded user)

### DIFF
--- a/pkg/api/logger.go
+++ b/pkg/api/logger.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/sosedoff/pgweb/pkg/command"
 )
 
 var (
@@ -29,6 +30,7 @@ func SetLogger(l *logrus.Logger) {
 
 func RequestLogger(logger *logrus.Logger) gin.HandlerFunc {
 	debug := logger.Level > logrus.InfoLevel
+	logForwardedUser := command.Opts.LogForwardedUser
 
 	return func(c *gin.Context) {
 		start := time.Now()
@@ -60,6 +62,15 @@ func RequestLogger(logger *logrus.Logger) gin.HandlerFunc {
 
 		if reqID := getRequestID(c); reqID != "" {
 			fields["id"] = reqID
+		}
+
+		if logForwardedUser {
+			if forwardedUser := c.GetHeader("X-Forwarded-User"); forwardedUser != "" {
+				fields["forwarded_user"] = forwardedUser
+			}
+			if forwardedEmail := c.GetHeader("X-Forwarded-Email"); forwardedEmail != "" {
+				fields["forwarded_email"] = forwardedEmail
+			}
 		}
 
 		if err := c.Errors.Last(); err != nil {

--- a/pkg/api/logger.go
+++ b/pkg/api/logger.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+
 	"github.com/sosedoff/pgweb/pkg/command"
 )
 

--- a/pkg/api/logger.go
+++ b/pkg/api/logger.go
@@ -58,6 +58,10 @@ func RequestLogger(logger *logrus.Logger) gin.HandlerFunc {
 			"path":        path,
 		}
 
+		if reqID := getRequestID(c); reqID != "" {
+			fields["id"] = reqID
+		}
+
 		if err := c.Errors.Last(); err != nil {
 			fields["error"] = err.Error()
 		}
@@ -87,4 +91,12 @@ func RequestLogger(logger *logrus.Logger) gin.HandlerFunc {
 
 func sanitizeLogPath(str string) string {
 	return reConnectToken.ReplaceAllString(str, "/connect/REDACTED")
+}
+
+func getRequestID(c *gin.Context) string {
+	id := c.GetHeader("x-request-id")
+	if id == "" {
+		id = c.GetHeader("x-amzn-trace-id")
+	}
+	return id
 }

--- a/pkg/api/logger_test.go
+++ b/pkg/api/logger_test.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getRequestID(t *testing.T) {
+	examples := []struct {
+		headers map[string]string
+		result  string
+	}{
+		{map[string]string{}, ""},
+		{map[string]string{"X-Request-ID": "foo"}, "foo"},
+		{map[string]string{"x-request-id": "foo"}, "foo"},
+		{map[string]string{"x-request-id": "foo"}, "foo"},
+		{map[string]string{"x-request-id": "foo", "x-amzn-trace-id": "amz"}, "foo"},
+	}
+
+	for _, ex := range examples {
+		req := &http.Request{Header: http.Header{}}
+		for k, v := range ex.headers {
+			req.Header.Set(k, v)
+		}
+
+		assert.Equal(t, ex.result, getRequestID(&gin.Context{Request: req}))
+	}
+}

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -23,6 +23,7 @@ type Options struct {
 	Debug                        bool   `short:"d" long:"debug" description:"Enable debugging mode"`
 	LogLevel                     string `long:"log-level" description:"Logging level" default:"info"`
 	LogFormat                    string `long:"log-format" description:"Logging output format" default:"text"`
+	LogForwardedUser             bool   `long:"log-forwarded-user" description:"Log user information available in X-Forwarded-User/Email headers"`
 	URL                          string `long:"url" description:"Database connection string"`
 	Host                         string `long:"host" description:"Server hostname or IP" default:"localhost"`
 	Port                         int    `long:"port" description:"Server port" default:"5432"`


### PR DESCRIPTION
This adds a few extra pieces of information to the log output:

- `id` - Adds request ID if detected via `X-Request-ID` / `X-Amzn-Trace-ID` headers, these usually set by a loadbalancer
- `forwarded_user` `forwarded_email` - Coming from `X-Forwarded-User/Email` headers. Useful to log when running pgweb behind tools like oauth2-proxy