### PR TITLE
Display empty schemas on the sidebar

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -234,6 +234,12 @@ func testDatabases(t *testing.T) {
 	assertMatches(t, []string{"booktown", "postgres"}, res)
 }
 
+func testSchemas(t *testing.T) {
+	res, err := testClient.Schemas()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"public"}, res)
+}
+
 func testObjects(t *testing.T) {
 	res, err := testClient.Objects()
 	objects := ObjectsFromResult(res)
@@ -617,6 +623,7 @@ func TestAll(t *testing.T) {
 	testInfo(t)
 	testActivity(t)
 	testDatabases(t)
+	testSchemas(t)
 	testObjects(t)
 	testTable(t)
 	testTableRows(t)

--- a/pkg/statements/sql/objects.sql
+++ b/pkg/statements/sql/objects.sql
@@ -20,7 +20,7 @@ WITH all_objects AS (
     pg_catalog.pg_namespace n ON n.oid = c.relnamespace
   WHERE
     c.relkind IN ('r','v','m','S','s','')
-    AND n.nspname !~ '^pg_toast'
+    AND n.nspname !~ '^pg_(toast|temp)'
     AND n.nspname NOT IN ('information_schema', 'pg_catalog')
     AND has_schema_privilege(n.nspname, 'USAGE')
 
@@ -38,7 +38,7 @@ WITH all_objects AS (
   JOIN
     pg_catalog.pg_proc p ON p.pronamespace = n.oid
   WHERE
-    n.nspname !~ '^pg_toast'
+    n.nspname !~ '^pg_(toast|temp)'
     AND n.nspname NOT IN ('information_schema', 'pg_catalog')
 )
 SELECT * FROM all_objects

--- a/pkg/statements/sql/schemas.sql
+++ b/pkg/statements/sql/schemas.sql
@@ -4,6 +4,6 @@ FROM
   information_schema.schemata
 WHERE
   schema_name NOT IN ('information_schema', 'pg_catalog')
-  AND schema_name !~ '^pg_toast'
+  AND schema_name !~ '^pg_(toast|temp)'
 ORDER BY
   schema_name ASC

--- a/pkg/statements/sql/schemas.sql
+++ b/pkg/statements/sql/schemas.sql
@@ -2,5 +2,8 @@ SELECT
   schema_name
 FROM
   information_schema.schemata
+WHERE
+  schema_name NOT IN ('information_schema', 'pg_catalog')
+  AND schema_name !~ '^pg_toast'
 ORDER BY
   schema_name ASC


### PR DESCRIPTION
This replaces #501 with minimal changes to the `/api/objects` call and utilizes already existing `/api/schemas` call to fetch all available schemas (without system ones)