### PR TITLE
Configure timeout and retries when testing connection status

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -453,8 +453,14 @@ func GetHistory(c *gin.Context) {
 
 // GetConnectionInfo renders information about current connection
 func GetConnectionInfo(c *gin.Context) {
-	res, err := DB(c).Info()
+	conn := DB(c)
 
+	if err := conn.TestWithTimeout(5 * time.Second); err != nil {
+		badRequest(c, err)
+		return
+	}
+
+	res, err := conn.Info()
 	if err != nil {
 		badRequest(c, err)
 		return


### PR DESCRIPTION
Fixes the confusing behavior when previously established connection is broken, prompting user with connection screen on page load. However, when page is simply reloaded, the UI works as expected. This has to do with database driver automatically reestablishing connection in the mean time, after the first failed attempt to get connection details.

Changes will allow us to automatically reconnect within 5 seconds when checking on connection status via `/api/connection` endpoint. 

- Does not introduce additional delays for local connections.
- Allows database driver test connection with 5s timeout.
- Allows automatic retries with 250ms delays, with max 20 retries.

Supersedes #533 