### PR TITLE
Add query execution stats to api endpoint

### DIFF
--- a/pkg/client/result.go
+++ b/pkg/client/result.go
@@ -42,9 +42,19 @@ type (
 	}
 
 	Result struct {
-		Pagination *Pagination `json:"pagination,omitempty"`
-		Columns    []string    `json:"columns"`
-		Rows       []Row       `json:"rows"`
+		Pagination *Pagination  `json:"pagination,omitempty"`
+		Columns    []string     `json:"columns"`
+		Rows       []Row        `json:"rows"`
+		Stats      *ResultStats `json:"stats,omitempty"`
+	}
+
+	ResultStats struct {
+		ColumnsCount    int       `json:"columns_count"`
+		RowsCount       int       `json:"rows_count"`
+		RowsAffected    int64     `json:"rows_affected"`
+		QueryStartTime  time.Time `json:"query_start_time"`
+		QueryFinishTime time.Time `json:"query_finish_time"`
+		QueryDuration   int64     `json:"query_duration_ms"`
 	}
 
 	Object struct {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -416,7 +416,7 @@ function buildTable(results, sortColumn, sortOrder, options) {
   $("#results_body").html(rows);
 
   // Show number of rows rendered on the page
-  $("#result-rows-count").html(results.rows.length + " rows");
+  $("#result-rows-count").html(results.stats.rows_count + " rows in " + results.stats.query_duration_ms + " ms");
 }
 
 function setCurrentTab(id) {


### PR DESCRIPTION
New response structure would include a new field:

```json
{
  "columns": [],
  "rows": [],
  "stats": {
    "columns_count": 3,
    "rows_count": 100,
    "rows_affected": 0,
    "query_start_time": "2022-12-25T19:06:55.893384Z",
    "query_finish_time": "2022-12-25T19:06:56.828875Z",
    "query_duration_ms": 935
  }
}
```