### PR TITLE
Add bookmark options to load username/password from env vars

### DIFF
--- a/pkg/bookmarks/bookmarks.go
+++ b/pkg/bookmarks/bookmarks.go
@@ -1,21 +1,25 @@
 package bookmarks
 
 import (
+	"os"
+
 	"github.com/sosedoff/pgweb/pkg/command"
 	"github.com/sosedoff/pgweb/pkg/shared"
 )
 
 // Bookmark contains information about bookmarked database connection
 type Bookmark struct {
-	ID       string          // ID generated from the filename
-	URL      string          // Postgres connection URL
-	Host     string          // Server hostname
-	Port     int             // Server port
-	User     string          // Database user
-	Password string          // User password
-	Database string          // Database name
-	SSLMode  string          // Connection SSL mode
-	SSH      *shared.SSHInfo // SSH tunnel config
+	ID          string          // ID generated from the filename
+	URL         string          // Postgres connection URL
+	Host        string          // Server hostname
+	Port        int             // Server port
+	User        string          // Database user
+	UserVar     string          // Database user environment variable
+	Password    string          // User password
+	PasswordVar string          // User password environment variable
+	Database    string          // Database name
+	SSLMode     string          // Connection SSL mode
+	SSH         *shared.SSHInfo // SSH tunnel config
 }
 
 // SSHInfoIsEmpty returns true if ssh configuration is not provided
@@ -25,12 +29,22 @@ func (b Bookmark) SSHInfoIsEmpty() bool {
 
 // ConvertToOptions returns an options struct from connection details
 func (b Bookmark) ConvertToOptions() command.Options {
+	user := b.User
+	if b.User == "" {
+		user = os.Getenv(b.UserVar)
+	}
+
+	pass := b.Password
+	if b.Password == "" {
+		pass = os.Getenv(b.PasswordVar)
+	}
+
 	return command.Options{
 		URL:     b.URL,
 		Host:    b.Host,
 		Port:    b.Port,
-		User:    b.User,
-		Pass:    b.Password,
+		User:    user,
+		Pass:    pass,
 		DbName:  b.Database,
 		SSLMode: b.SSLMode,
 	}

--- a/pkg/bookmarks/bookmarks_test.go
+++ b/pkg/bookmarks/bookmarks_test.go
@@ -35,6 +35,63 @@ func TestBookmarkSSHInfoIsEmpty(t *testing.T) {
 	})
 }
 
+func TestBookmarkWithVarsConvertToOptions(t *testing.T) {
+	t.Run("literals set", func(t *testing.T) {
+		b := Bookmark{
+			User:        "user",
+			UserVar:     "",
+			Password:    "password",
+			PasswordVar: "",
+		}
+
+		expOpt := command.Options{
+			User: "user",
+			Pass: "password",
+		}
+
+		opt := b.ConvertToOptions()
+		assert.Equal(t, expOpt, opt)
+	})
+
+	t.Run("all set", func(t *testing.T) {
+		b := Bookmark{
+			User:        "user",
+			UserVar:     "DB_USER",
+			Password:    "password",
+			PasswordVar: "DB_PASSWORD",
+		}
+
+		expOpt := command.Options{
+			User: "user",
+			Pass: "password",
+		}
+
+		t.Setenv("DB_USER", "user123")
+		t.Setenv("DB_PASSWORD", "password123")
+		opt := b.ConvertToOptions()
+		assert.Equal(t, expOpt, opt)
+	})
+
+	t.Run("env vars set", func(t *testing.T) {
+		b := Bookmark{
+			User:        "",
+			UserVar:     "DB_USER",
+			Password:    "",
+			PasswordVar: "DB_PASSWORD",
+		}
+
+		expOpt := command.Options{
+			User: "user123",
+			Pass: "password123",
+		}
+
+		t.Setenv("DB_USER", "user123")
+		t.Setenv("DB_PASSWORD", "password123")
+		opt := b.ConvertToOptions()
+		assert.Equal(t, expOpt, opt)
+	})
+}
+
 func TestBookmarkConvertToOptions(t *testing.T) {
 	b := Bookmark{
 		URL:      "postgres://username:password@host:port/database?sslmode=disable",


### PR DESCRIPTION
We keep our configuration for pgweb in a private Git repository. Currently we still have to input the username and password every time, but it would be nice to refer to an environment variable in the bookmarks. That'll allow us to have the 'click-and-go' functionality without the security implications of keeping passwords stored in the repository itself. Using SSH keys is unfortunately not an option.