### PR TITLE
Better Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,14 @@
 FROM golang:1.19-bullseye AS build
 
 WORKDIR /build
-ADD . /build
 
 RUN git config --global --add safe.directory /build
+COPY go.mod go.sum ./
 RUN go mod download
+COPY Makefile main.go ./
+COPY static/ static/
+COPY pkg/ pkg/
+COPY .git/ .
 RUN make build
 
 # ------------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
   pgweb:
     container_name: pgweb
     image: sosedoff/pgweb:latest
+    build: .
     environment:
       PGWEB_DATABASE_URL: postgres://pgweb:pgweb@pgweb-postgres:5432/pgweb?sslmode=disable
     ports:


### PR DESCRIPTION
Fix #644.

I created a new stage to handle the key, so that many tools do not end up in the final image, then I further simplified both the build and release stage. This reduced the image size from ~200 MB to ~160 MB, and reduced the build time as well. I also removed `apt-key`, which is deprecated, used quiet mode for apt, and avoided installed recommended packages.

I dropped the postgres client as well, as it is needed just when running the tests. By doing that, the only external dependency is `nc`, which is provided by a minimal `busybox:musl` image (<1 MB). The final image ~15 MB, which is ~92 % less of the original image. Since I was not sure if this is the desired result, I kept the commit split.
Since the binary is now built with `CGO_ENABLED=0`, there is no need to use a golang image based on Debian, so the alpine version is used instead.

Replacing `nc` with a different way to do a self-check would further reduce the image, but using `scratch` as the base image could be problematic for some users, that are used to have a minimal shell within the container.

As the last step, I added https://github.com/eficode/wait-for, a small POSIX shell script, to wait for Postgres without having to rely on specific docker compose functionalities, which are not available in other systems. `depends_on` does not even work in some Docker environments. I replaced the health check that used `nc` with `wait-for`, which tries to establish a http connection by default.

The software works as usual, but a review would be helpful.
I also added `build: .` to allow local builds using `docker compose`.

The current version requires 27 seconds to be built, and its size 197 MB (`docker system prune -af && time rootlesskit docker build --no-cache .`). This includes the image pull from the server. In my case, I am using a gigabit connection, so the impact of using larger images is small, but it could affect other users more.
Using the same criteria, the version proposed in this PR takes 20 seconds to be built, and its size is 16 MB.

Possible improvements for the future:
- make git an optional requirement, so that `.git` should not be copied when building the image, and `git` installation could be skipped as well;
- use `RUN --mount=type=cache,mode=0755,target=/go/pkg/mod` and similar to avoid downloading dependencies multiple times when there is a minor change;
- unbundle web static assets, so that they can be served independently of the backend if needed;
- add end-to-end test using the Docker image.