### PR TITLE
Use entrypoint instead of cmd for the pgweb binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,4 @@ RUN \
 COPY --from=build /build/pgweb /usr/bin/pgweb
 
 EXPOSE 8081
-
-CMD ["/usr/bin/pgweb", "--bind=0.0.0.0", "--listen=8081"]
+ENTRYPOINT ["/usr/bin/pgweb", "--bind=0.0.0.0", "--listen=8081"]


### PR DESCRIPTION
This is a very small change in the Dockerfile which facilitates passing of arguments to the container/pgweb. This allows specifying additional arguments _directly_ after `docker run`, e.g.:

 `docker run --rm sosedoff/pgweb --listen=8082` or `docker run sosedoff/pgweb -h` to display the help message.
Currently, when running for example `docker run sosedoff/pgweb -h` to check for the help message, this fails because it will try to look up the arguments in $PATH.

See https://docs.docker.com/engine/reference/builder/#entrypoint and https://docs.docker.com/engine/reference/builder/#cmd. 