### PR TITLE
Implement process uptime metric

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -61,6 +61,6 @@ func SetupRoutes(router *gin.Engine) {
 
 func SetupMetrics(engine *gin.Engine) {
 	if command.Opts.MetricsEnabled && command.Opts.MetricsAddr == "" {
-		engine.GET("/metrics", gin.WrapH(metrics.Handler()))
+		engine.GET("/metrics", gin.WrapH(metrics.NewHandler()))
 	}
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -61,6 +61,7 @@ func SetupRoutes(router *gin.Engine) {
 
 func SetupMetrics(engine *gin.Engine) {
 	if command.Opts.MetricsEnabled && command.Opts.MetricsAddr == "" {
+		// NOTE: We're not supporting the MetricsPath CLI option here to avoid the route conflicts.
 		engine.GET("/metrics", gin.WrapH(metrics.NewHandler()))
 	}
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -307,7 +307,8 @@ func Run() {
 		}
 	}
 
-	// Start a separate metrics http server
+	// Start a separate metrics http server. If metrics addr is not provided, we
+	// add the metrics endpoint in the existing application server (see api.go).
 	if options.MetricsEnabled && options.MetricsAddr != "" {
 		go startMetricsServer()
 	}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -307,6 +307,7 @@ func Run() {
 		}
 	}
 
+	// Start a separate metrics http server
 	if options.MetricsEnabled && options.MetricsAddr != "" {
 		go startMetricsServer()
 	}

--- a/pkg/metrics/handler.go
+++ b/pkg/metrics/handler.go
@@ -1,0 +1,25 @@
+package metrics
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+type Handler struct {
+	startTime   time.Time
+	promHandler http.Handler
+}
+
+func (h Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	uptimeGauge.Set(time.Since(h.startTime).Seconds())
+	h.promHandler.ServeHTTP(rw, req)
+}
+
+func NewHandler() http.Handler {
+	return Handler{
+		startTime:   time.Now(),
+		promHandler: promhttp.Handler(),
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,6 +20,11 @@ var (
 		Name: "pgweb_healthy",
 		Help: "Server health status",
 	})
+
+	uptimeGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "pgweb_uptime",
+		Help: "Server application uptime in seconds",
+	})
 )
 
 func IncrementQueriesCount() {

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -3,17 +3,12 @@ package metrics
 import (
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 )
-
-func Handler() http.Handler {
-	return promhttp.Handler()
-}
 
 func StartServer(logger *logrus.Logger, path string, addr string) error {
 	logger.WithField("addr", addr).WithField("path", path).Info("starting prometheus metrics server")
 
-	http.Handle(path, Handler())
+	http.Handle(path, NewHandler())
 	return http.ListenAndServe(addr, nil)
 }


### PR DESCRIPTION
This adds a new `pgweb_uptime` prom metric in `/metrics` to report the total process uptime.