### PR TITLE
Do not run image as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,4 @@ COPY --from=build /build/pgweb /usr/bin/pgweb
 
 EXPOSE 8081
 ENTRYPOINT ["/usr/bin/pgweb", "--bind=0.0.0.0", "--listen=8081"]
+USER 1000


### PR DESCRIPTION
This PR changes the default user of the application image to 1000 as docker images should not be running as root user.