### PR TITLE
Dockerfile: wait for postgres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,11 @@ RUN . /etc/os-release && \
     apt-get install -qq --no-install-recommends ca-certificates openssl netcat curl postgresql-client
 
 COPY --from=build /build/pgweb /usr/bin/pgweb
+COPY entrypoint.sh /
 
 RUN useradd --uid 1000 --no-create-home --shell /bin/false pgweb
 USER pgweb
 
 EXPOSE 8081
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/bin/pgweb", "--bind=0.0.0.0", "--listen=8081"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ RUN useradd --uid 1000 --no-create-home --shell /bin/false pgweb
 USER pgweb
 
 EXPOSE 8081
-ENTRYPOINT ["/usr/bin/pgweb", "--bind=0.0.0.0", "--listen=8081"]
+CMD ["/usr/bin/pgweb", "--bind=0.0.0.0", "--listen=8081"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Wait for PostgreSQL
+while ! psql -Xq "$PGWEB_DATABASE_URL" -c "select 1" &>/dev/null
+do
+    sleep 5s
+done
+
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Wait for PostgreSQL
-while ! psql -Xq "$PGWEB_DATABASE_URL" -c "select 1" &>/dev/null
+for i in {1..5}
 do
+    psql -Xq "$PGWEB_DATABASE_URL" -c "select 1" &>/dev/null && break
     sleep 5s
 done
 


### PR DESCRIPTION
Sometimes pgweb starts before Postgres, and it fails, because Postgres is slower to start, or it has to initialize its database or recover. This makes it try until Postgres is available.

Two commits:
1. Execute the pgweb command as command instead of entrypoint
2. Use script as entrypoint which waits for Postgres to be available