### PR TITLE
Allow retrying a connection on startup

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -261,8 +261,9 @@ func openPage() {
 	}
 }
 
-// testWithRetry attempts to establish a database connection until it succeeds or
-// give up after certain number of retries.
+// testClient attempts to establish a database connection until it succeeds or
+// give up after certain number of retries. Retries only available when database
+// name or a connection string is provided.
 func testClient(cl *client.Client, retryCount int, retryDelay time.Duration) (abort bool, err error) {
 	usingDefaultDB := command.Opts.DbName == "" && command.Opts.URL == ""
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -80,7 +80,7 @@ func initClient() {
 	retryDelay := time.Second * time.Duration(command.Opts.RetryDelay)
 
 	fmt.Println("Connecting to server...")
-	abort, err := testClient(cl, retryCount, retryDelay)
+	abort, err := testClient(cl, int(retryCount), retryDelay)
 	if err != nil {
 		if abort {
 			exitWithMessage(err.Error())

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -272,7 +272,7 @@ func testClient(cl *client.Client, retryCount int, retryDelay time.Duration) (ab
 			return false, nil
 		}
 
-		// AContinue normal start up if can't connect locally without database details.
+		// Continue normal start up if can't connect locally without database details.
 		if usingDefaultDB {
 			if errors.Is(err, client.ErrConnectionRefused) ||
 				errors.Is(err, client.ErrAuthFailed) ||

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -35,9 +34,6 @@ SECURITY WARNING: You are running Pgweb in read-only mode.
 This mode is designed for environments where users could potentially delete or change data.
 For proper read-only access please follow PostgreSQL role management documentation.
 --------------------------------------------------------------------------------`
-
-	regexErrConnectionRefused = regexp.MustCompile(`(connection|actively) refused`)
-	regexErrAuthFailed        = regexp.MustCompile(`authentication failed`)
 )
 
 func init() {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	neturl "net/url"
 	"reflect"
+	"regexp"
 	"strings"
 	"time"
 
@@ -19,6 +20,18 @@ import (
 	"github.com/sosedoff/pgweb/pkg/history"
 	"github.com/sosedoff/pgweb/pkg/shared"
 	"github.com/sosedoff/pgweb/pkg/statements"
+)
+
+var (
+	regexErrAuthFailed        = regexp.MustCompile(`authentication failed`)
+	regexErrConnectionRefused = regexp.MustCompile(`(connection|actively) refused`)
+	regexErrDatabaseNotExist  = regexp.MustCompile(`database "(.*)" does not exist`)
+)
+
+var (
+	ErrAuthFailed        = errors.New("authentication failed")
+	ErrConnectionRefused = errors.New("connection refused")
+	ErrDatabaseNotExist  = errors.New("database does not exist")
 )
 
 type Client struct {
@@ -179,7 +192,27 @@ func (client *Client) setServerVersion() {
 }
 
 func (client *Client) Test() error {
-	return client.db.Ping()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := client.db.PingContext(ctx)
+	if err == nil {
+		return nil
+	}
+
+	errMsg := err.Error()
+
+	if regexErrConnectionRefused.MatchString(errMsg) {
+		return ErrConnectionRefused
+	}
+	if regexErrAuthFailed.MatchString(errMsg) {
+		return ErrAuthFailed
+	}
+	if regexErrDatabaseNotExist.MatchString(errMsg) {
+		return ErrDatabaseNotExist
+	}
+
+	return err
 }
 
 func (client *Client) TestWithTimeout(timeout time.Duration) (result error) {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -192,6 +192,7 @@ func (client *Client) setServerVersion() {
 }
 
 func (client *Client) Test() error {
+	// NOTE: This is a different timeout defined in CLI OpenTimeout
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	regexErrAuthFailed        = regexp.MustCompile(`authentication failed`)
+	regexErrAuthFailed        = regexp.MustCompile(`(authentication failed|role "(.*)" does not exist)`)
 	regexErrConnectionRefused = regexp.MustCompile(`(connection|actively) refused`)
 	regexErrDatabaseNotExist  = regexp.MustCompile(`database "(.*)" does not exist`)
 )

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -217,7 +217,7 @@ func testTest(t *testing.T) {
 		},
 		{
 			name:  "invalid user",
-			input: fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", "foo", serverHost, serverPort, serverDatabase),
+			input: fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", "foo", serverPassword, serverHost, serverPort, serverDatabase),
 			err:   ErrAuthFailed,
 		},
 		{

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sosedoff/pgweb/pkg/command"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -199,7 +200,46 @@ func testClientIdleTime(t *testing.T) {
 }
 
 func testTest(t *testing.T) {
-	assert.NoError(t, testClient.Test())
+	examples := []struct {
+		name  string
+		input string
+		err   error
+	}{
+		{
+			name:  "success",
+			input: fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, serverDatabase),
+			err:   nil,
+		},
+		{
+			name:  "connection refused",
+			input: "postgresql://localhost:5433/dbname",
+			err:   ErrConnectionRefused,
+		},
+		{
+			name:  "invalid user",
+			input: fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", "foo", serverHost, serverPort, serverDatabase),
+			err:   ErrAuthFailed,
+		},
+		{
+			name:  "invalid password",
+			input: fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", serverUser, "foo", serverHost, serverPort, serverDatabase),
+			err:   ErrAuthFailed,
+		},
+		{
+			name:  "invalid database",
+			input: fmt.Sprintf("postgres://%s@%s:%s/%s?sslmode=disable", serverUser, serverHost, serverPort, "foo"),
+			err:   ErrDatabaseNotExist,
+		},
+	}
+
+	for _, ex := range examples {
+		t.Run(ex.name, func(t *testing.T) {
+			conn, err := NewFromUrl(ex.input, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, ex.err, conn.Test())
+		})
+	}
 }
 
 func testInfo(t *testing.T) {

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -37,7 +37,7 @@ type Options struct {
 	SSLCert                      string `long:"ssl-cert" description:"SSL client certificate file"`
 	SSLKey                       string `long:"ssl-key" description:"SSL client certificate key file"`
 	OpenTimeout                  int    `long:"open-timeout" description:"Maximum wait time for connection, in seconds" default:"30"`
-	RetryDelay                   int    `long:"open-retry-delay" description:"Number of seconds to wait before retrying the connection" default:"1"`
+	RetryDelay                   int    `long:"open-retry-delay" description:"Number of seconds to wait before retrying the connection" default:"3"`
 	RetryCount                   int    `long:"open-retry" description:"Number of times to retry establishing connection" default:"0"`
 	HTTPHost                     string `long:"bind" description:"HTTP server host" default:"localhost"`
 	HTTPPort                     uint   `long:"listen" description:"HTTP server listen port" default:"8081"`

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -36,7 +36,9 @@ type Options struct {
 	SSLRootCert                  string `long:"ssl-rootcert" description:"SSL certificate authority file"`
 	SSLCert                      string `long:"ssl-cert" description:"SSL client certificate file"`
 	SSLKey                       string `long:"ssl-key" description:"SSL client certificate key file"`
-	OpenTimeout                  int    `long:"open-timeout" description:" Maximum wait for connection, in seconds" default:"30"`
+	OpenTimeout                  int    `long:"open-timeout" description:"Maximum wait time for connection, in seconds" default:"30"`
+	RetryDelay                   int    `long:"open-retry-delay" description:"Number of seconds to wait before retrying the connection" default:"1"`
+	RetryCount                   int    `long:"open-retry" description:"Number of times to retry establishing connection" default:"0"`
 	HTTPHost                     string `long:"bind" description:"HTTP server host" default:"localhost"`
 	HTTPPort                     uint   `long:"listen" description:"HTTP server listen port" default:"8081"`
 	AuthUser                     string `long:"auth-user" description:"HTTP basic auth user"`

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -37,8 +37,8 @@ type Options struct {
 	SSLCert                      string `long:"ssl-cert" description:"SSL client certificate file"`
 	SSLKey                       string `long:"ssl-key" description:"SSL client certificate key file"`
 	OpenTimeout                  int    `long:"open-timeout" description:"Maximum wait time for connection, in seconds" default:"30"`
-	RetryDelay                   int    `long:"open-retry-delay" description:"Number of seconds to wait before retrying the connection" default:"3"`
-	RetryCount                   int    `long:"open-retry" description:"Number of times to retry establishing connection" default:"0"`
+	RetryDelay                   uint   `long:"open-retry-delay" description:"Number of seconds to wait before retrying the connection" default:"3"`
+	RetryCount                   uint   `long:"open-retry" description:"Number of times to retry establishing connection" default:"0"`
 	HTTPHost                     string `long:"bind" description:"HTTP server host" default:"localhost"`
 	HTTPPort                     uint   `long:"listen" description:"HTTP server listen port" default:"8081"`
 	AuthUser                     string `long:"auth-user" description:"HTTP basic auth user"`


### PR DESCRIPTION
Add ability to retry establishing a new connection if configuration permits:

- New feature disabled by default
- If enabled, skip retrying if database name or connection URL string is not provided
- If enabled, retry for 5 times with 3 seconds delay (configurable)