### PR TITLE
Allow setting readonly mode in bookmarks

### DIFF
--- a/pkg/bookmarks/bookmarks.go
+++ b/pkg/bookmarks/bookmarks.go
@@ -20,6 +20,7 @@ type Bookmark struct {
 	Database    string          // Database name
 	SSLMode     string          // Connection SSL mode
 	SSH         *shared.SSHInfo // SSH tunnel config
+	ReadOnly    bool            // Enable read-only transaction mode
 }
 
 // SSHInfoIsEmpty returns true if ssh configuration is not provided
@@ -40,12 +41,13 @@ func (b Bookmark) ConvertToOptions() command.Options {
 	}
 
 	return command.Options{
-		URL:     b.URL,
-		Host:    b.Host,
-		Port:    b.Port,
-		User:    user,
-		Pass:    pass,
-		DbName:  b.Database,
-		SSLMode: b.SSLMode,
+		URL:      b.URL,
+		Host:     b.Host,
+		Port:     b.Port,
+		User:     user,
+		Pass:     pass,
+		DbName:   b.Database,
+		SSLMode:  b.SSLMode,
+		ReadOnly: b.ReadOnly,
 	}
 }

--- a/pkg/bookmarks/bookmarks_test.go
+++ b/pkg/bookmarks/bookmarks_test.go
@@ -68,6 +68,7 @@ func TestBookmarkWithVarsConvertToOptions(t *testing.T) {
 
 		t.Setenv("DB_USER", "user123")
 		t.Setenv("DB_PASSWORD", "password123")
+
 		opt := b.ConvertToOptions()
 		assert.Equal(t, expOpt, opt)
 	})
@@ -87,6 +88,7 @@ func TestBookmarkWithVarsConvertToOptions(t *testing.T) {
 
 		t.Setenv("DB_USER", "user123")
 		t.Setenv("DB_PASSWORD", "password123")
+
 		opt := b.ConvertToOptions()
 		assert.Equal(t, expOpt, opt)
 	})
@@ -101,16 +103,18 @@ func TestBookmarkConvertToOptions(t *testing.T) {
 		Password: "password",
 		Database: "mydatabase",
 		SSLMode:  "disable",
+		ReadOnly: true,
 	}
 
 	expOpt := command.Options{
-		URL:     "postgres://username:password@host:port/database?sslmode=disable",
-		Host:    "localhost",
-		Port:    5432,
-		User:    "postgres",
-		Pass:    "password",
-		DbName:  "mydatabase",
-		SSLMode: "disable",
+		URL:      "postgres://username:password@host:port/database?sslmode=disable",
+		Host:     "localhost",
+		Port:     5432,
+		User:     "postgres",
+		Pass:     "password",
+		DbName:   "mydatabase",
+		SSLMode:  "disable",
+		ReadOnly: true,
 	}
 
 	opt := b.ConvertToOptions()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -679,6 +679,14 @@ func testReadOnlyMode(t *testing.T) {
 
 	_, err = client.Query("/* CREATE TABLE foobar(id integer); */ SELECT 'foo';")
 	assert.NoError(t, err)
+
+	t.Run("with local readonly flag", func(t *testing.T) {
+		command.Opts.ReadOnly = false
+		client.readonly = true
+
+		_, err := client.Query("INSERT INTO foobar(id) VALUES(1)")
+		assert.Error(t, err, "query contains keywords not allowed in read-only mode")
+	})
 }
 
 func testTablesStats(t *testing.T) {


### PR DESCRIPTION
Bookmarks now support a new option `readonly` to put the connection into readonly transaction mode, already supported by `--readonly` CLI flag.