### PR TITLE
Continue on parseJSON error

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -85,7 +85,14 @@ function apiCall(method, path, params, cb) {
           return cb({ error: "Query timeout after " + timeout + "s" });
       }
 
-      cb(jQuery.parseJSON(xhr.responseText));
+      var responseText;
+      try {
+        responseText = jQuery.parseJSON(xhr.responseText);
+      }
+      catch {
+        responseText = { error: "Failed to parse the JSON response." };
+      }
+      cb(responseText);
     }
   });
 }


### PR DESCRIPTION
In some instances (where an ingress redirects 4xx errors for instance), the response by the server on error will not necessarily be neatly JSON formatted.

This causes pgweb to halt loading the page on a jQuery error.
This PR adds a `try` `catch` statement to catch `parseJSON` errors and resume code execution on a failed API call.