### PR TITLE
fix missing indexes by quoting schema/table name to ::regclass

### DIFF
--- a/pkg/statements/sql/table_indexes.sql
+++ b/pkg/statements/sql/table_indexes.sql
@@ -1,6 +1,6 @@
 SELECT
   indexname AS index_name,
-  pg_size_pretty(pg_table_size((schemaname || '.' || indexname)::regclass)) AS index_size,
+  pg_size_pretty(pg_table_size(('"' || schemaname || '"."' || indexname || '"')::regclass)) AS index_size,
   indexdef AS index_definition
 FROM
   pg_indexes


### PR DESCRIPTION
The same approach is used in [`pkg/statements/sql/table_schema.sql`](https://github.com/sosedoff/pgweb/blob/v0.14.3/pkg/statements/sql/table_schema.sql#L8) and a sample reproduction for the bug is:

```sql
CREATE SCHEMA test;
CREATE TABLE test.data (id INTEGER PRIMARY KEY, name TEXT);
CREATE UNIQUE INDEX "test.data_uniq" ON test.data (name);
```

Only the primary key is shown, and not the index created above.