### PR TITLE
Add support for a bookmarks-only mode

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -154,6 +154,8 @@ func Connect(c *gin.Context) {
 
 	if bookmarkID := c.Request.FormValue("bookmark_id"); bookmarkID != "" {
 		cl, err = ConnectWithBookmark(bookmarkID)
+	} else if command.Opts.BookmarksOnly {
+		err = errNotPermitted
 	} else {
 		cl, err = ConnectWithURL(c)
 	}
@@ -558,9 +560,10 @@ func GetInfo(c *gin.Context) {
 	successResponse(c, gin.H{
 		"app": command.Info,
 		"features": gin.H{
-			"session_lock":  command.Opts.LockSession,
-			"query_timeout": command.Opts.QueryTimeout,
-			"local_queries": QueryStore != nil,
+			"session_lock":   command.Opts.LockSession,
+			"query_timeout":  command.Opts.QueryTimeout,
+			"local_queries":  QueryStore != nil,
+			"bookmarks_only": command.Opts.BookmarksOnly,
 		},
 	})
 }

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -167,6 +167,18 @@ func ParseOptions(args []string) (Options, error) {
 		}
 	}
 
+	if opts.BookmarksOnly == true {
+		if opts.URL != "" {
+			return opts, errors.New("--url not supported in bookmarks-only mode")
+		}
+		if opts.Host != "localhost" {
+			return opts, errors.New("--host not supported in bookmarks-only mode")
+		}
+		if opts.ConnectBackend != "" {
+			return opts, errors.New("--connect-backend not supported in bookmarks-only mode")
+		}
+	}
+
 	homePath, err := homedir.Dir()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[WARN] cant detect home dir: %v", err)

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -167,11 +167,11 @@ func ParseOptions(args []string) (Options, error) {
 		}
 	}
 
-	if opts.BookmarksOnly == true {
+	if opts.BookmarksOnly {
 		if opts.URL != "" {
 			return opts, errors.New("--url not supported in bookmarks-only mode")
 		}
-		if opts.Host != "localhost" {
+		if opts.Host != "" && opts.Host != "localhost" {
 			return opts, errors.New("--host not supported in bookmarks-only mode")
 		}
 		if opts.ConnectBackend != "" {

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -50,6 +50,7 @@ type Options struct {
 	LockSession                  bool   `long:"lock-session" description:"Lock session to a single database connection"`
 	Bookmark                     string `short:"b" long:"bookmark" description:"Bookmark to use for connection. Bookmark files are stored under $HOME/.pgweb/bookmarks/*.toml" default:""`
 	BookmarksDir                 string `long:"bookmarks-dir" description:"Overrides default directory for bookmark files to search" default:""`
+	BookmarksOnly                bool   `long:"bookmarks-only" description:"Allow only connections from bookmarks"`
 	QueriesDir                   string `long:"queries-dir" description:"Overrides default directory for local queries"`
 	DisablePrettyJSON            bool   `long:"no-pretty-json" description:"Disable JSON formatting feature for result export"`
 	DisableSSH                   bool   `long:"no-ssh" description:"Disable database connections via SSH"`
@@ -116,6 +117,10 @@ func ParseOptions(args []string) (Options, error) {
 		} else {
 			opts.Host = ""
 		}
+	}
+
+	if getPrefixedEnvVar("BOOKMARKS_ONLY") != "" {
+		opts.BookmarksOnly = true
 	}
 
 	if getPrefixedEnvVar("SESSIONS") != "" {

--- a/pkg/command/options_test.go
+++ b/pkg/command/options_test.go
@@ -80,4 +80,18 @@ func TestParseOptions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "../../data/passfile", opts.Passfile)
 	})
+
+	t.Run("bookmarks only mode", func(t *testing.T) {
+		_, err := ParseOptions([]string{"--bookmarks-only"})
+		assert.NoError(t, err)
+
+		_, err = ParseOptions([]string{"--bookmarks-only", "--url", "test"})
+		assert.EqualError(t, err, "--url not supported in bookmarks-only mode")
+
+		_, err = ParseOptions([]string{"--bookmarks-only", "--host", "test", "--port", "5432"})
+		assert.EqualError(t, err, "--host not supported in bookmarks-only mode")
+
+		_, err = ParseOptions([]string{"--bookmarks-only", "--connect-backend", "test", "--sessions", "--connect-token", "token", "--url", "127.0.0.2"})
+		assert.EqualError(t, err, "--connect-backend not supported in bookmarks-only mode")
+	})
 }

--- a/static/index.html
+++ b/static/index.html
@@ -189,14 +189,16 @@
           </div>
         </div>
 
-        <div class="connection-standard-group">
+        <div class="connection-bookmarks-group">
           <div class="form-group bookmarks">
             <label class="col-sm-3 control-label">Bookmark</label>
             <div class="col-sm-9">
               <select class="form-control" id="connection_bookmarks"></select>
             </div>
           </div>
+        </div>
 
+        <div class="connection-standard-group">
           <div class="form-group">
             <label class="col-sm-3 control-label">Host</label>
             <div class="col-sm-9">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1084,6 +1084,7 @@ function showConnectionSettings() {
   // Show the current postgres version
   $(".connection-settings .version").text("v" + appInfo.version).show();
   $("#connection_window").show();
+  initConnectionWindow();
 
   // Check github release page for updates
   getLatestReleaseInfo(appInfo);
@@ -1115,6 +1116,22 @@ function showConnectionSettings() {
       $(".bookmarks").hide();
     }
   });
+}
+
+function initConnectionWindow() {
+  if (appFeatures.bookmarks_only) {
+    $(".connection-group-switch").hide();
+    $(".connection-scheme-group").hide();
+    $(".connection-bookmarks-group").show();
+    $(".connection-standard-group").hide();
+    $(".connection-ssh-group").hide();
+  } else {
+    $(".connection-group-switch").show();
+    $(".connection-scheme-group").hide();
+    $(".connection-bookmarks-group").show();
+    $(".connection-standard-group").show();
+    $(".connection-ssh-group").hide();
+  }
 }
 
 function getConnectionString() {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1113,7 +1113,12 @@ function showConnectionSettings() {
       $(".bookmarks").show();
     }
     else {
-      $(".bookmarks").hide();
+      if (appFeatures.bookmarks_only) {
+        $("#connection_error").html("Running in <b>bookmarks-only</b> mode but <b>NO</b> bookmarks configured.").show();
+        $(".open-connection").hide();
+      } else {
+        $(".bookmarks").hide();
+      }
     }
   });
 }


### PR DESCRIPTION
This adds the ability to disable manually-entered connection details in favor of bookmarks.
Feel free to recommend any changes that better align with project directions.

The use-case for this self-hosting and avoiding users to ever provide connection details.
A connect backend is sortof similar, but bookmarks already go 90% of the way and come baked-in.