### PR TITLE
Switch base image to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # Builder Stage
 # ------------------------------------------------------------------------------
-FROM golang:1.20-bullseye AS build
+FROM golang:1.20-bookworm AS build
 
 WORKDIR /build
 
@@ -15,30 +15,11 @@ COPY .git/ .
 RUN make build
 
 # ------------------------------------------------------------------------------
-# Fetch signing key
-# ------------------------------------------------------------------------------
-FROM debian:bullseye-slim AS keyring
-ADD https://www.postgresql.org/media/keys/ACCC4CF8.asc keyring.asc
-RUN apt-get update && \
-    apt-get install -qq --no-install-recommends gpg
-RUN gpg -o keyring.pgp --dearmor keyring.asc
-
-# ------------------------------------------------------------------------------
 # Release Stage
 # ------------------------------------------------------------------------------
-FROM debian:bullseye-slim
-
-ARG keyring=/usr/share/keyrings/postgresql-archive-keyring.pgp
-COPY --from=keyring /keyring.pgp $keyring
-RUN . /etc/os-release && \
-    echo "deb [signed-by=${keyring}] http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
-    apt-get update && \
-    apt-get install -qq --no-install-recommends ca-certificates openssl netcat curl postgresql-client
+FROM gcr.io/distroless/base-debian12
 
 COPY --from=build /build/pgweb /usr/bin/pgweb
-
-RUN useradd --uid 1000 --no-create-home --shell /bin/false pgweb
-USER pgweb
 
 EXPOSE 8081
 ENTRYPOINT ["/usr/bin/pgweb", "--bind=0.0.0.0", "--listen=8081"]


### PR DESCRIPTION
This a conversation fueled by CVEs mainly.

Scanned the latest released with Trivy:
```bash
docker run --rm -it aquasec/trivy image ghcr.io/sosedoff/pgweb:0.15.0
```
And here's the overview:
```
ghcr.io/sosedoff/pgweb:0.15.0 (debian 11.9)
Total: 163 (UNKNOWN: 0, LOW: 91, MEDIUM: 28, HIGH: 40, CRITICAL: 4)

usr/bin/pgweb (gobinary)
Total: 5 (UNKNOWN: 0, LOW: 0, MEDIUM: 4, HIGH: 1, CRITICAL: 0)
```

Looking at the history of this project it was once `alpine`: bc4a90774c4b807b8cf58cb92e23a18797bdc323 
Actually wanted to suggest it as a base image since it has decent developer experience compared to distroless, if you don't have to deal with `musl` specifically.

What follows is just a test I did on how hard it would be to make it `distroless`.
Not very, as it seems - though I don't know about those deps since I didn't need any in my testing.

Here are a few options for this conversation:
- switching back to `alpine`, decent devx, small, almost no CVEs
- switch to `distroless`, works as far as I can tell but it's a pain to build once you have to deal with deps
- publish multiple versions, requires manging multiple Dockerfiles but shouldn't be too hard
- upgrade base image to `bookworm` at least since some of the CVEs have already been resolved but are not scheduled to be backported
- do nothing 😋 interested parties can build their own variant fairly easily