### PR TITLE
fix: Propagate CGO_ENABLED environment variable to docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,3 +33,5 @@ jobs:
           push: false
           tags: pgweb:latest
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          build-args: |
+            "CGO_ENABLED=${{ env.CGO_ENABLED }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 FROM golang:1.22-bullseye AS build
 
-# Set default build argument for CGO_ENABLED=0. This can be overriden by build-args
+# Set default build argument for CGO_ENABLED
 ARG CGO_ENABLED=0
 ENV CGO_ENABLED ${CGO_ENABLED}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY Makefile main.go ./
 COPY static/ static/
 COPY pkg/ pkg/
 COPY .git/ .
-RUN make build
+RUN make build STATIC=true
 
 # ------------------------------------------------------------------------------
 # Fetch signing key

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 # ------------------------------------------------------------------------------
 FROM golang:1.22-bullseye AS build
 
+# Set default build argument for CGO_ENABLED=0. This can be overriden by build-args
+ARG CGO_ENABLED=0
+ENV CGO_ENABLED ${CGO_ENABLED}
+
 WORKDIR /build
 
 RUN git config --global --add safe.directory /build
@@ -12,7 +16,7 @@ COPY Makefile main.go ./
 COPY static/ static/
 COPY pkg/ pkg/
 COPY .git/ .
-RUN make build STATIC=true
+RUN make build
 
 # ------------------------------------------------------------------------------
 # Fetch signing key

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,6 @@ LDFLAGS += -X $(PKG)/pkg/command.GitCommit=$(GIT_COMMIT)
 LDFLAGS += -X $(PKG)/pkg/command.BuildTime=$(BUILD_TIME)
 LDFLAGS += -X $(PKG)/pkg/command.GoVersion=$(GO_VERSION)
 
-ifeq ($(STATIC), true)
-	CGO_ENABLED = 0
-endif
-
 usage:
 	@echo ""
 	@echo "Task                 : Description"
@@ -46,16 +42,16 @@ dev:
 	@echo "You can now execute ./pgweb"
 
 build:
-	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags '${LDFLAGS}'
+	go build -ldflags '${LDFLAGS}'
 	@echo "You can now execute ./pgweb"
 
 install:
-	CGO_ENABLED=$(CGO_ENABLED) go install -ldflags '${LDFLAGS}'
+	go install -ldflags '${LDFLAGS}'
 	@echo "You can now execute pgweb"
 
 release: clean
 	@echo "Building binaries..."
-	@CGO_ENABLED=$(CGO_ENABLED) LDFLAGS='${LDFLAGS}' ./script/build_all.sh
+	@LDFLAGS='${LDFLAGS}' ./script/build_all.sh
 
 clean:
 	@echo "Removing all artifacts"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ LDFLAGS += -X $(PKG)/pkg/command.GitCommit=$(GIT_COMMIT)
 LDFLAGS += -X $(PKG)/pkg/command.BuildTime=$(BUILD_TIME)
 LDFLAGS += -X $(PKG)/pkg/command.GoVersion=$(GO_VERSION)
 
+ifeq ($(STATIC), true)
+	CGO_ENABLED = 0
+endif
+
 usage:
 	@echo ""
 	@echo "Task                 : Description"
@@ -42,16 +46,16 @@ dev:
 	@echo "You can now execute ./pgweb"
 
 build:
-	go build -ldflags '${LDFLAGS}'
+	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags '${LDFLAGS}'
 	@echo "You can now execute ./pgweb"
 
 install:
-	go install -ldflags '${LDFLAGS}'
+	CGO_ENABLED=$(CGO_ENABLED) go install -ldflags '${LDFLAGS}'
 	@echo "You can now execute pgweb"
 
 release: clean
 	@echo "Building binaries..."
-	@LDFLAGS='${LDFLAGS}' ./script/build_all.sh
+	@CGO_ENABLED=$(CGO_ENABLED) LDFLAGS='${LDFLAGS}' ./script/build_all.sh
 
 clean:
 	@echo "Removing all artifacts"


### PR DESCRIPTION
# Description

This PR aims to enable the generation of statically linked binaries for increased portability and ease of deployment. Selfishly we would like to use your upstream docker images and copy the binary across to our internal base image so we can use a tool like dependabot/renovate to keep up to date with the latest version.

Please let me know if you would like this be handled in a different way

# Changes
- Updated the Makefile to conditionally set CGO_ENABLED=0 when the STATIC flag is provided.
- Ensured that the STATIC flag can be toggled via the Makefile, allowing flexibility in the build process.

# Testing
```
[statically-compiled-binaries] burdz@~/code/pgweb: make release 
Removing all artifacts
Building binaries...
-> target: darwin/amd64
-> target: darwin/arm64
-> target: linux/amd64
-> target: linux/arm64
-> target: windows/amd64
-> target: arm/v5
-> target: arm64/v7
[statically-compiled-binaries] burdz@~/code/pgweb: for file in "bin/*"; do file $file; done
bin/pgweb_darwin_amd64:   Mach-O 64-bit x86_64 executable, flags:<|DYLDLINK|PIE>
bin/pgweb_darwin_arm64:   Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
bin/pgweb_linux_amd64:    ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=Eel_FR4ifLWGHvxRUiT9/OM0f38rHo0olim4ke5eZ/FTVPCQyzkE-4Y_9B2klm/pruHN4XmwQDMpCbxqri8, stripped
bin/pgweb_linux_arm64:    ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=uT8vDBaFlEbA8Lj0S4wo/DOn6kasaXhsYi8gPFy9G/0sUxCZepX6jDdv5y0fNx/YPQ4ekXfT5egNy8Omdt3, stripped
bin/pgweb_linux_arm64_v7: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=uT8vDBaFlEbA8Lj0S4wo/DOn6kasaXhsYi8gPFy9G/0sUxCZepX6jDdv5y0fNx/YPQ4ekXfT5egNy8Omdt3, stripped
bin/pgweb_linux_arm_v5:   ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=jHqYeORzcXUpvJWkRUoi/RymztH6G6e6EKSrxtIof/QWb0xR0_nf3bYktZ7pmf/J5M9YNTfEla0HRsBzFCO, stripped
bin/pgweb_windows_amd64:  PE32+ executable (console) x86-64, for MS Windows
[statically-compiled-binaries] burdz@~/code/pgweb: make release STATIC=true
Removing all artifacts
Building binaries...
-> target: darwin/amd64
-> target: darwin/arm64
-> target: linux/amd64
-> target: linux/arm64
-> target: windows/amd64
-> target: arm/v5
-> target: arm64/v7
[statically-compiled-binaries] burdz@~/code/pgweb: for file in "bin/*"; do file $file; done
bin/pgweb_darwin_amd64:   Mach-O 64-bit x86_64 executable, flags:<|DYLDLINK|PIE>
bin/pgweb_darwin_arm64:   Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
bin/pgweb_linux_amd64:    ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=QO4Lwqu070Bsj_mcwulF/vgcadX5SjtZvNi31KyjW/Xe5M7aUseLRj4_Kkxap5/ByKC_tHd1BEn_jap73u_, stripped
bin/pgweb_linux_arm64:    ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=tGXvkH2I5oI6GN0qrU4i/sEkMs-2KuGzJgcr0qhnA/0sUxCZepX6jDdv5y0fNx/PSLnwpVICcbXUsrkw0wH, stripped
bin/pgweb_linux_arm64_v7: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=tGXvkH2I5oI6GN0qrU4i/sEkMs-2KuGzJgcr0qhnA/0sUxCZepX6jDdv5y0fNx/PSLnwpVICcbXUsrkw0wH, stripped
bin/pgweb_linux_arm_v5:   ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=d6bB18NN55mF5jCeTwz_/hsHJM3VlGMrIYkyUIrvC/QWb0xR0_nf3bYktZ7pmf/G0cRRC2-8pLBWJepAFtd, stripped
bin/pgweb_windows_amd64:  PE32+ executable (console) x86-64, for MS Windows
```