### PR TITLE
Drop linux/arm/v5 from docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,4 +32,4 @@ jobs:
           context: .
           push: false
           tags: pgweb:latest
-          platforms: linux/amd64,linux/arm64,linux/arm/v5,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
The target arch is not available for go1.22