### PR TITLE
Allow database stats downloads

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -538,6 +538,8 @@ func GetTablesStats(c *gin.Context) {
 		c.JSON(http.StatusOK, res)
 	case "csv":
 		c.Data(http.StatusOK, "text/csv", res.CSV())
+	case "xml":
+		c.XML(200, res)
 	default:
 		badRequest(c, "invalid format")
 	}

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -155,11 +155,12 @@ func assetContentType(name string) string {
 
 // Send a query result to client
 func serveResult(c *gin.Context, result interface{}, err interface{}) {
-	if err == nil {
-		successResponse(c, result)
-	} else {
+	if err != nil {
 		badRequest(c, err)
+		return
 	}
+
+	successResponse(c, result)
 }
 
 // Send successful response back to client

--- a/static/index.html
+++ b/static/index.html
@@ -324,7 +324,9 @@
   </div>
   <div id="current_database_context_menu">
     <ul class="dropdown-menu" role="menu">
-      <li><a href="#" data-action="show_tables_stats">Show Tables Stats</a></li>
+      <li><a href="#" data-action="show_db_stats">Show Database Stats</a></li>
+      <li><a href="#" data-action="download_db_stats">Download Database Stats</a></li>
+      <li class="divider"></li>
       <li><a href="#" data-action="export">Export SQL dump</a></li>
     </ul>
   </div>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -660,7 +660,7 @@ function showPaginatedTableContent() {
   showTableContent(sortColumn, sortOrder);
 }
 
-function showTablesStats() {
+function showDatabaseStats() {
   getTablesStats(function(data) {
     buildTable(data);
 
@@ -669,6 +669,10 @@ function showTablesStats() {
     $("#body").prop("class", "full");
     $("#results").addClass("no-crop");
   });
+}
+
+function downloadDatabaseStats() {
+  openInNewWindow("api/tables_stats", { format: "csv", export: "true" });
 }
 
 function showTableStructure() {
@@ -1267,8 +1271,11 @@ function bindCurrentDatabaseMenu() {
       var menuItem = $(e.target);
 
       switch(menuItem.data("action")) {
-        case "show_tables_stats":
-          showTablesStats();
+        case "show_db_stats":
+          showDatabaseStats();
+          break;
+        case "download_db_stats":
+          downloadDatabaseStats();
           break;
         case "export":
           openInNewWindow("api/export");


### PR DESCRIPTION
Adds a new context menu item to download the database stats. Previously it was only possible to view the stats, but having option to download comes quite handy if one needs to share the stats with non users.