### PR TITLE
fix: Propagate CGO_ENABLED environment variable in release docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,5 @@ jobs:
             ghcr.io/${{ env.GHCR_REPOSITORY }}:${{ steps.refs.outputs.SOURCE_TAG }}
             ghcr.io/${{ env.GHCR_REPOSITORY }}:latest
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          build-args: |
+            "CGO_ENABLED=${{ env.CGO_ENABLED }}"


### PR DESCRIPTION
Sorry in https://github.com/sosedoff/pgweb/pull/724 I didn't notice earlier that release.yaml had a seperate build step. This fixes that. Thanks