### PR TITLE
Shorten git revision printed in the --version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKG = github.com/sosedoff/pgweb
-GIT_COMMIT ?= $(shell git rev-parse HEAD)
+GIT_COMMIT ?= $(shell git rev-parse --short=8 HEAD)
 BUILD_TIME ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ" | tr -d '\n')
 GO_VERSION ?= $(shell go version | awk {'print $$3'})
 


### PR DESCRIPTION
Shortens the git SHA length used in the output of `--version` from 32 to 8 characters.