### PR TITLE
Fix database switching

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -249,7 +249,7 @@ func SwitchDb(c *gin.Context) {
 		badRequest(c, errInvalidConnString)
 		return
 	}
-	currentURL.Path = name
+	currentURL.Path = "/" + name
 
 	cl, err := client.NewFromUrl(currentURL.String(), nil)
 	if err != nil {


### PR DESCRIPTION
**Issue**
Database switching fails because the current URL path is replaced with the database name, causing the leading / to be missing. This results in incorrect URL resolution.

**Fix**
Ensure the replacement retains the leading / when updating the URL path with the new database name.