### PR TITLE
WIP: Session refresh

### DIFF
--- a/pkg/api/backend.go
+++ b/pkg/api/backend.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -27,7 +28,8 @@ type BackendRequest struct {
 
 // BackendCredential represents the third-party response
 type BackendCredential struct {
-	DatabaseURL string `json:"database_url"`
+	DatabaseURL   string    `json:"database_url"`
+	SessionExpiry time.Time `json:"session_expiry"`
 }
 
 // FetchCredential sends an authentication request to a third-party service

--- a/pkg/api/session_manager.go
+++ b/pkg/api/session_manager.go
@@ -10,9 +10,15 @@ import (
 	"github.com/sosedoff/pgweb/pkg/metrics"
 )
 
+type Session struct {
+	Client         *client.Client
+	SessionExpiry  time.Time
+	SessionRefresh func(*Session) (*Session, error)
+}
+
 type SessionManager struct {
 	logger      *logrus.Logger
-	sessions    map[string]*client.Client
+	sessions    map[string]*Session
 	mu          sync.Mutex
 	idleTimeout time.Duration
 }
@@ -20,7 +26,7 @@ type SessionManager struct {
 func NewSessionManager(logger *logrus.Logger) *SessionManager {
 	return &SessionManager{
 		logger:   logger,
-		sessions: map[string]*client.Client{},
+		sessions: map[string]*Session{},
 		mu:       sync.Mutex{},
 	}
 }
@@ -46,10 +52,15 @@ func (m *SessionManager) Sessions() map[string]*client.Client {
 	sessions := m.sessions
 	m.mu.Unlock()
 
-	return sessions
+	mapOfClients := map[string]*client.Client{}
+	for k, v := range sessions {
+		mapOfClients[k] = v.Client
+	}
+
+	return mapOfClients
 }
 
-func (m *SessionManager) Get(id string) *client.Client {
+func (m *SessionManager) GetSession(id string) *Session {
 	m.mu.Lock()
 	c := m.sessions[id]
 	m.mu.Unlock()
@@ -57,26 +68,84 @@ func (m *SessionManager) Get(id string) *client.Client {
 	return c
 }
 
+func (m *SessionManager) Get(id string) *client.Client {
+	m.mu.Lock()
+	c := m.sessions[id]
+	m.mu.Unlock()
+
+	if c == nil {
+		return nil
+	}
+
+	return c.Client
+}
+
 func (m *SessionManager) Add(id string, conn *client.Client) {
+	m.AddSession(id, &Session{
+		Client: conn,
+	})
+}
+
+func (m *SessionManager) AddSession(id string, session *Session) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.sessions[id] = conn
+	if session.Client == nil && session.SessionRefresh != nil {
+		var err error
+		session, err = session.SessionRefresh(session)
+		if err != nil {
+			return err
+		}
+	}
+	m.sessions[id] = session
+
 	metrics.SetSessionsCount(len(m.sessions))
+	return nil
 }
 
 func (m *SessionManager) Remove(id string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	conn, ok := m.sessions[id]
+	session, ok := m.sessions[id]
 	if ok {
-		conn.Close()
+		session.Client.Close()
 		delete(m.sessions, id)
 	}
 
 	metrics.SetSessionsCount(len(m.sessions))
 	return ok
+}
+
+func (m *SessionManager) RefreshSession(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, ok := m.sessions[id]
+	if !ok {
+		// session not found
+		return nil
+	}
+
+	if session.SessionRefresh == nil || session.SessionExpiry.IsZero() {
+		// ClientFactory or SessionExpiry is not set so it is impossible to refresh
+		// the session
+		return nil
+	}
+
+	if session.SessionExpiry.After(time.Now()) {
+		// session has not expired yet
+		return nil
+	}
+
+	session, err := session.SessionRefresh(session)
+	if err != nil {
+		return err
+	}
+
+	m.sessions[id] = session
+
+	return nil
 }
 
 func (m *SessionManager) Len() int {
@@ -118,17 +187,42 @@ func (m *SessionManager) RunPeriodicCleanup() {
 }
 
 func (m *SessionManager) staleSessions() []string {
-	m.mu.TryLock()
+	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	now := time.Now()
 	ids := []string{}
 
-	for id, conn := range m.sessions {
-		if now.Sub(conn.LastQueryTime()) > m.idleTimeout {
+	for id, session := range m.sessions {
+		if now.Sub(session.Client.LastQueryTime()) > m.idleTimeout {
 			ids = append(ids, id)
 		}
 	}
 
 	return ids
+}
+
+func (m *SessionManager) RefreshSessions() error {
+	m.mu.Lock()
+	sessions := m.sessions
+	m.mu.Unlock()
+
+	for id := range sessions {
+		if err := m.RefreshSession(id); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *SessionManager) RunPeriodicRefresh() {
+	m.logger.Info("session manager refresh enabled")
+
+	for range time.Tick(time.Minute) {
+		if err := m.RefreshSessions(); err != nil {
+			// TODO: better error handling and logging
+			m.logger.Error("error refreshing sessions:", err)
+		}
+	}
 }

--- a/pkg/api/session_manager_test.go
+++ b/pkg/api/session_manager_test.go
@@ -16,8 +16,8 @@ func TestSessionManager(t *testing.T) {
 		manager := NewSessionManager(nil)
 		assert.Equal(t, []string{}, manager.IDs())
 
-		manager.sessions["foo"] = &client.Client{}
-		manager.sessions["bar"] = &client.Client{}
+		manager.sessions["foo"] = &Session{Client: &client.Client{}}
+		manager.sessions["bar"] = &Session{Client: &client.Client{}}
 
 		ids := manager.IDs()
 		sort.Strings(ids)
@@ -28,7 +28,7 @@ func TestSessionManager(t *testing.T) {
 		manager := NewSessionManager(nil)
 		assert.Nil(t, manager.Get("foo"))
 
-		manager.sessions["foo"] = &client.Client{}
+		manager.sessions["foo"] = &Session{Client: &client.Client{}}
 		assert.NotNil(t, manager.Get("foo"))
 	})
 
@@ -53,8 +53,8 @@ func TestSessionManager(t *testing.T) {
 
 	t.Run("return len", func(t *testing.T) {
 		manager := NewSessionManager(nil)
-		manager.sessions["foo"] = &client.Client{}
-		manager.sessions["bar"] = &client.Client{}
+		manager.sessions["foo"] = &Session{Client: &client.Client{}}
+		manager.sessions["bar"] = &Session{Client: &client.Client{}}
 
 		assert.Equal(t, 2, manager.Len())
 	})

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -106,6 +106,7 @@ func setup() {
 
 	out, err := exec.Command(
 		testCommands["createdb"],
+		"-w",
 		"-U", serverUser,
 		"-h", serverHost,
 		"-p", serverPort,
@@ -120,6 +121,7 @@ func setup() {
 
 	out, err = exec.Command(
 		testCommands["psql"],
+		"-w",
 		"-U", serverUser,
 		"-h", serverHost,
 		"-p", serverPort,
@@ -148,6 +150,7 @@ func teardownClient() {
 func teardown(t *testing.T, allowFail bool) {
 	output, err := exec.Command(
 		testCommands["dropdb"],
+		"-w",
 		"-U", serverUser,
 		"-h", serverHost,
 		"-p", serverPort,


### PR DESCRIPTION
This adds session refresh functionality to pgweb, as discussed in #799. Right now it's a bit of a hack, there's quite a few TODOs and FIXMEs, and there aren't any tests. But I figured I would throw up this draft PR to start getting eyes on it.

I went with adding a new `session_expiry` field that takes an RFC 3339 timestamp. Every minute on a background goroutine it checks all of the sessions and if any of them have expired it will refresh them.

There are some tradeoffs with this approach.

1. Each `api.Session` has a `SessionRefresh` callback that is used for the session refresh and initial session setup. This works well enough but it does make the callstack a little more complicated.
2. `api.Session` _could potentially_ be rolled into `client.Client` but it seemed trickier than just a new struct. But if `SessionManager` isn't used then there has to be a different way that sessions are refreshed so it's a little weird right now.
3. Since session expiry is only checked once a minute you could end up in a situation where pgweb tries to use credentials that have already expired. An alternative approach could be to spin up a goroutine that sleeps until it is just the right time and then refreshes the credentials so there's no chance for expired credentials to ever be used, but that's a little more complicated than a `for` loop with `time.Tick`.
4. `api.DbClient` isn't used directly anymore and `api.DbSession` is used instead, but a pointer to the `client.Client` is kept in that variable. It's an exported variable so I wasn't sure how much we care about package API breaking changes. 
5. On that note, there aren't any exported API breaking changes, but there are some weird inconsistencies as a result of that; for instance `SessionManager.Sessions()` returns a map of `*client.Client` and not `*Session`. If all of the refresh stuff was in `client.Client` then this wouldn't be an issue.

Again, just wanted to get this draft PR up. I'll keep iterating on it in the meantime. Let me know your thoughts on this approach.

Fixes #799 

