### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -95,9 +95,9 @@ jobs:
           fetch-depth: 0
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.57.1
+          version: v2.6.0
 
   fmt:
     name: fmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+version: "2"
+linters:
+  disable:
+    - errcheck
+  settings:
+    staticcheck:
+      checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1005", "-QF1004"]


### PR DESCRIPTION
Using even the latest v1 `golangci-lint:v1.64.8` supports at most Go 1.24 which will be a problem when updating Go **1.25**
> Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25)

This change upgrades `golangci-lint` to v2.6.0 but does not aim to resolve the 37 issues found.
32x Error return value of `<func>` is not checked
3x ST1005: error strings should not be capitalized 
2x QF1004: could use strings.ReplaceAll instead