### PR TITLE
Build with Go v1.25

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ on:
 
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -95,9 +95,9 @@ jobs:
           fetch-depth: 0
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.8
+          version: v2.7.2
 
   fmt:
     name: fmt

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25"
   CGO_ENABLED: 0
   IMAGE_REPOSITORY: sosedoff/pgweb
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25"
   CGO_ENABLED: 0
   DOCKER_REPOSITORY: sosedoff/pgweb
   GHCR_REPOSITORY: sosedoff/pgweb

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+version: "2"
+linters:
+  disable:
+    - errcheck
+  settings:
+    staticcheck:
+      checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1005", "-QF1004"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # Builder Stage
 # ------------------------------------------------------------------------------
-FROM golang:1.24-bullseye AS build
+FROM golang:1.25-trixie AS build
 
 # Set default build argument for CGO_ENABLED
 ARG CGO_ENABLED=0
@@ -21,7 +21,7 @@ RUN make build
 # ------------------------------------------------------------------------------
 # Fetch signing key
 # ------------------------------------------------------------------------------
-FROM debian:bullseye-slim AS keyring
+FROM debian:trixie-slim AS keyring
 ADD https://www.postgresql.org/media/keys/ACCC4CF8.asc keyring.asc
 RUN apt-get update && \
     apt-get install -qq --no-install-recommends gpg
@@ -30,14 +30,14 @@ RUN gpg -o keyring.pgp --dearmor keyring.asc
 # ------------------------------------------------------------------------------
 # Release Stage
 # ------------------------------------------------------------------------------
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 
 ARG keyring=/usr/share/keyrings/postgresql-archive-keyring.pgp
 COPY --from=keyring /keyring.pgp $keyring
 RUN . /etc/os-release && \
     echo "deb [signed-by=${keyring}] http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
-    apt-get install -qq --no-install-recommends ca-certificates openssl netcat curl postgresql-client
+    apt-get install -qq --no-install-recommends ca-certificates openssl netcat-openbsd curl postgresql-client
 
 COPY --from=build /build/pgweb /usr/bin/pgweb
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/sosedoff/pgweb
 
-go 1.24.0
+go 1.25
 
-toolchain go1.24.3
+toolchain go1.25.4
 
 require (
 	github.com/BurntSushi/toml v1.1.0


### PR DESCRIPTION
Use Go v1.25 toolchain to build the service on top of the latest debian 13 release.

This change also upgrades `golangci-lint` to v2.7.2 which is required for Go 1.25 but does not aim to resolve the 34 issues found.
29x Error return value of `<func>` is not checked
3x ST1005: error strings should not be capitalized 
2x QF1004: could use strings.ReplaceAll instead