### PR TITLE
Bump golangci-lint version in CI to v1.64.8

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,7 +97,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.62.2
+          version: v1.64.8
 
   fmt:
     name: fmt


### PR DESCRIPTION
Updates the `golangci-lint` version to the most recent v1.x