### PR TITLE
Add timeouts to metrics HTTP server

### DIFF
--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -9,6 +10,17 @@ import (
 func StartServer(logger *logrus.Logger, path string, addr string) error {
 	logger.WithField("addr", addr).WithField("path", path).Info("starting prometheus metrics server")
 
-	http.Handle(path, NewHandler())
-	return http.ListenAndServe(addr, nil)
+	mux := http.NewServeMux()
+	mux.Handle(path, NewHandler())
+
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	return server.ListenAndServe()
 }


### PR DESCRIPTION
Replace `http.ListenAndServe` with a custom `http.Server` in the metrics server to configure read, write and idle timeouts. This prevents the server from being vulnerable to slowloris-style resource exhaustion attacks.

Also switches from registering on `http.DefaultServeMux` to a dedicated `http.ServeMux` to avoid potential route conflicts.