### PR TITLE
Add --no-connect-ui flag to hide connect/disconnect buttons

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -143,7 +143,7 @@ func ConnectWithBackend(c *gin.Context) {
 
 // Connect creates a new client connection
 func Connect(c *gin.Context) {
-	if command.Opts.LockSession {
+	if command.Opts.LockSession || command.Opts.DisableConnectUI {
 		badRequest(c, errSessionLocked)
 		return
 	}
@@ -281,7 +281,7 @@ func SwitchDb(c *gin.Context) {
 
 // Disconnect closes the current database connection
 func Disconnect(c *gin.Context) {
-	if command.Opts.LockSession {
+	if command.Opts.LockSession || command.Opts.DisableConnectUI {
 		badRequest(c, errSessionLocked)
 		return
 	}
@@ -483,6 +483,7 @@ func GetConnectionInfo(c *gin.Context) {
 
 	info := res.Format()[0]
 	info["session_lock"] = command.Opts.LockSession
+	info["no_connect_ui"] = command.Opts.DisableConnectUI
 
 	successResponse(c, info)
 }
@@ -603,6 +604,7 @@ func GetInfo(c *gin.Context) {
 		"app": command.Info,
 		"features": gin.H{
 			"session_lock":   command.Opts.LockSession,
+			"no_connect_ui": command.Opts.DisableConnectUI,
 			"query_timeout":  command.Opts.QueryTimeout,
 			"local_queries":  QueryStore != nil,
 			"bookmarks_only": command.Opts.BookmarksOnly,

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -48,6 +48,7 @@ type Options struct {
 	Prefix                       string `long:"prefix" description:"Add a url prefix"`
 	ReadOnly                     bool   `long:"readonly" description:"Run database connection in readonly mode"`
 	LockSession                  bool   `long:"lock-session" description:"Lock session to a single database connection"`
+	DisableConnectUI             bool   `long:"no-connect-ui" description:"Disable connect/disconnect buttons in the UI"`
 	Bookmark                     string `short:"b" long:"bookmark" description:"Bookmark to use for connection. Bookmark files are stored under $HOME/.pgweb/bookmarks/*.toml" default:""`
 	BookmarksDir                 string `long:"bookmarks-dir" description:"Overrides default directory for bookmark files to search" default:""`
 	BookmarksOnly                bool   `long:"bookmarks-only" description:"Allow only connections from bookmarks"`
@@ -130,6 +131,10 @@ func ParseOptions(args []string) (Options, error) {
 	if getPrefixedEnvVar("LOCK_SESSION") != "" {
 		opts.LockSession = true
 		opts.Sessions = false
+	}
+
+	if getPrefixedEnvVar("NO_CONNECT_UI") != "" {
+		opts.DisableConnectUI = true
 	}
 
 	if opts.Sessions || opts.ConnectBackend != "" {
@@ -243,6 +248,7 @@ func AvailableEnvVars() string {
 		"  " + envVarPrefix + "URL_PREFIX    HTTP server path prefix",
 		"  " + envVarPrefix + "SESSIONS      Enable multiple database sessions",
 		"  " + envVarPrefix + "LOCK_SESSION  Lock session to a single database connection",
+		"  " + envVarPrefix + "NO_CONNECT_UI Disable connect/disconnect buttons in the UI",
 		"  " + envVarPrefix + "AUTH_USER     HTTP basic auth username",
 		"  " + envVarPrefix + "AUTH_PASS     HTTP basic auth password",
 		"  " + envVarPrefix + "BOOKMARKS_DIR Overrides default directory for bookmark files",

--- a/pkg/command/options_test.go
+++ b/pkg/command/options_test.go
@@ -101,6 +101,21 @@ func TestParseOptions(t *testing.T) {
 		assert.Equal(t, flagDir, opts.BookmarksDir)
 	})
 
+	t.Run("no connect ui from env var", func(t *testing.T) {
+		os.Setenv("PGWEB_NO_CONNECT_UI", "1")
+		defer os.Unsetenv("PGWEB_NO_CONNECT_UI")
+
+		opts, err := ParseOptions([]string{})
+		assert.NoError(t, err)
+		assert.True(t, opts.DisableConnectUI)
+	})
+
+	t.Run("no connect ui from flag", func(t *testing.T) {
+		opts, err := ParseOptions([]string{"--no-connect-ui"})
+		assert.NoError(t, err)
+		assert.True(t, opts.DisableConnectUI)
+	})
+
 	t.Run("bookmarks only mode", func(t *testing.T) {
 		_, err := ParseOptions([]string{"--bookmarks-only"})
 		assert.NoError(t, err)

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1903,7 +1903,7 @@ $(document).ready(function() {
       $("#current_database").text(resp.current_database);
       $("#main").show();
 
-      if (!appFeatures.session_lock) {
+      if (!appFeatures.session_lock && !appFeatures.no_connect_ui) {
         $(".connection-actions").show();
       }
     });


### PR DESCRIPTION
When running pgweb with a pre-configured DATABASE_URL in environments like K8S, the connect/disconnect buttons can cause confusion to users. The existing `--lock-session` flag hides these buttons but also disables database switching, which is too restrictive when users need to browse multiple databases on the same server.

This adds a `--no-connect-ui` flag (and `PGWEB_NO_CONNECT_UI` env var) that hides the connect/disconnect buttons while still allowing users to switch between databases.