### PR TITLE
Update README: PostgreSQL 9.1+ → 9.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Very easy to use and packs just the right amount of features.
 - Cross-platform: Mac/Linux/Windows (64bit).
 - Simple installation (distributed as a single binary).
 - Zero dependencies.
-- Works with PostgreSQL 9.1+.
+- Works with PostgreSQL 9.6+.
 - Supports native SSH tunnels.
 - Multiple database sessions.
 - Execute and analyze custom SQL queries.


### PR DESCRIPTION
PG 9.1 has been EOL since 2014 and is no longer tested in CI (matrix runs 9.6–18). The codebase still has a 9.1-specific query in `statements/sql.go`, but CI and actual usage start at 9.6.