### PR TITLE
Update GoDoc badge to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple web-based and cross platform PostgreSQL database explorer.
 [![Release](https://img.shields.io/github/release/sosedoff/pgweb.svg?label=Release)](https://github.com/sosedoff/pgweb/releases)
 [![Linux Build](https://github.com/sosedoff/pgweb/actions/workflows/checks.yml/badge.svg)](https://github.com/sosedoff/pgweb/actions?query=branch%3Amain)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sosedoff/pgweb)](https://goreportcard.com/report/github.com/sosedoff/pgweb)
-[![GoDoc](https://godoc.org/github.com/sosedoff/pgweb?status.svg)](https://godoc.org/github.com/sosedoff/pgweb)
+[![GoDoc](https://pkg.go.dev/badge/github.com/sosedoff/pgweb)](https://pkg.go.dev/github.com/sosedoff/pgweb)
 [![Docker Pulls](https://img.shields.io/docker/pulls/sosedoff/pgweb.svg)](https://hub.docker.com/r/sosedoff/pgweb/)
 
 ## Overview


### PR DESCRIPTION
The old `godoc.org` domain was deprecated in 2021 and redirects to `pkg.go.dev`. Verified the new badge URL returns a valid SVG image:

- Old: https://godoc.org/github.com/sosedoff/pgweb?status.svg (still serves but deprecated)
- New: https://pkg.go.dev/badge/github.com/sosedoff/pgweb (confirmed working)