### PR TITLE
Update docker-compose.yml to PostgreSQL 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,11 @@
 services:
   postgres:
     container_name: pgweb-postgres
-    image: postgres:15
+    image: postgres:18
     ports:
       - 5433:5432
     volumes:
-      - data:/var/lib/postgresql/data
+      - data:/var/lib/postgresql
     environment:
       POSTGRES_DB: pgweb
       POSTGRES_PASSWORD: pgweb


### PR DESCRIPTION
Bump PostgreSQL from 15 to 18 in the main compose file.

- Image tag: `postgres:15` → `postgres:18`
- Volume path: `/var/lib/postgresql/data` → `/var/lib/postgresql` (required by PG 18+ Docker images due to major-version-specific subdirectory layout, see docker-library/postgres#1259)

Verified: pgweb connects to PostgreSQL 18.4 and API responds correctly.