### PR TITLE
client: block pg_cancel_backend and pg_terminate_backend in read-only mode

### DIFF
--- a/pkg/client/util.go
+++ b/pkg/client/util.go
@@ -10,6 +10,10 @@ var (
 	// List of keywords that are not allowed in read-only mode
 	reRestrictedKeywords = regexp.MustCompile(`(?mi)\s?(CREATE|INSERT|UPDATE|DROP|DELETE|TRUNCATE|GRANT|OPEN|IMPORT|COPY)\s`)
 
+	// Functions that mutate cross-session state and so aren't allowed in read-only
+	// mode even though Postgres itself permits them inside a read-only transaction.
+	reRestrictedFunctions = regexp.MustCompile(`(?i)\b(pg_cancel_backend|pg_terminate_backend)\s*\(`)
+
 	// Comment regular expressions
 	reSlashComment = regexp.MustCompile(`(?m)/\*.+\*/`)
 	reDashComment  = regexp.MustCompile(`(?m)--.+`)
@@ -85,7 +89,7 @@ func containsRestrictedKeywords(str string) bool {
 	str = reSlashComment.ReplaceAllString(str, "")
 	str = reDashComment.ReplaceAllString(str, "")
 
-	return reRestrictedKeywords.MatchString(str)
+	return reRestrictedKeywords.MatchString(str) || reRestrictedFunctions.MatchString(str)
 }
 
 func hasBinary(data string, checkLen int) bool {

--- a/pkg/client/util_test.go
+++ b/pkg/client/util_test.go
@@ -95,6 +95,31 @@ func TestGetMajorMinorVersion(t *testing.T) {
 	}
 }
 
+func TestContainsRestrictedKeywords(t *testing.T) {
+	examples := []struct {
+		input    string
+		expected bool
+	}{
+		{"SELECT 1", false},
+		{"SELECT * FROM pg_stat_activity", false},
+		{"INSERT INTO foo VALUES (1)", true},
+		{"CREATE TABLE foo (id int)", true},
+		{"SELECT pg_cancel_backend(123)", true},
+		{"select PG_CANCEL_BACKEND(123)", true},
+		{"select pg_cancel_backend (123)", true},
+		{"SELECT pg_terminate_backend(123)", true},
+		{"-- SELECT pg_cancel_backend(123)\nSELECT 1", false},
+		{"/* pg_cancel_backend(123) */ SELECT 1", false},
+		{"SELECT cancel_backend_log()", false},
+	}
+
+	for _, ex := range examples {
+		t.Run(ex.input, func(t *testing.T) {
+			assert.Equal(t, ex.expected, containsRestrictedKeywords(ex.input))
+		})
+	}
+}
+
 func TestCheckVersionRequirement(t *testing.T) {
 	examples := []struct {
 		client string


### PR DESCRIPTION
\`containsRestrictedKeywords\` only checked for write statements (CREATE, INSERT, UPDATE, DROP, etc), and Postgres' own read-only transaction guard happily lets you call \`pg_cancel_backend(pid)\` and \`pg_terminate_backend(pid)\` since they don't touch relations. So the activity page's Stop button (which sends \`SELECT pg_cancel_backend(...)\` via the regular query API) still worked against a \`--readonly\` deployment, which defeats the whole safety guarantee.

Added a second regex for the backend-control functions and OR'd it into \`containsRestrictedKeywords\`. Tests cover the \`SELECT\` call, case variations, stray whitespace, and a few negatives (substring match, comment-only, similarly-named functions).

fixes #853