### PR TITLE
fix: hide bookmarks when switching to scheme mode

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1789,16 +1789,19 @@ $(document).ready(function() {
         $(".connection-scheme-group").show();
         $(".connection-standard-group").hide();
         $(".connection-ssh-group").hide();
+        $(".connection-bookmarks-group").hide();
         return;
       case "standard":
         $(".connection-scheme-group").hide();
         $(".connection-standard-group").show();
         $(".connection-ssh-group").hide();
+        $(".connection-bookmarks-group").show();
         return;
       case "ssh":
         $(".connection-scheme-group").hide();
         $(".connection-standard-group").show();
         $(".connection-ssh-group").show();
+        $(".connection-bookmarks-group").show();
         return;
     }
   });


### PR DESCRIPTION
When switching to Scheme mode in the connection settings, the bookmarks section remained visible. This was introduced in commit 3c11ae5 (PR #716), which extracted bookmarks from inside `.connection-standard-group` into its own `.connection-bookmarks-group` sibling, but the mode switch handler was never updated to toggle its visibility.

**Changes:** Added `show()`/`hide()` calls for `.connection-bookmarks-group` in the mode switch handler at `static/js/app.js:1787-1806`.

- Scheme: bookmarks hidden
- Standard: bookmarks shown
- SSH: bookmarks shown